### PR TITLE
divers adjustements

### DIFF
--- a/Cours_SpatialR.log
+++ b/Cours_SpatialR.log
@@ -1,11 +1,13 @@
-This is XeTeX, Version 3.14159265-2.6-0.999991 (MiKTeX 2.9.7140 64-bit) (preloaded format=xelatex 2019.8.26)  10 JAN 2020 16:51
+This is pdfTeX, Version 3.14159265-2.6-1.40.19 (TeX Live 2019/dev/Debian) (preloaded format=pdflatex 2019.4.26)  27 MAY 2020 19:24
 entering extended mode
-**./Cours_SpatialR.tex
-(Cours_SpatialR.tex
+ restricted \write18 enabled.
+ %&-line parsing enabled.
+**Cours_SpatialR.tex
+(./Cours_SpatialR.tex
 LaTeX2e <2018-12-01>
-(krantz.cls
+(./krantz.cls
 Document Class: krantz 2005/09/16 v1.4f Standard LaTeX document class
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/base\bk12.clo"
+(/usr/share/texlive/texmf-dist/tex/latex/base/bk12.clo
 File: bk12.clo 2018/09/03 v1.4i Standard LaTeX file (size option)
 )
 \trimheight=\dimen102
@@ -97,7 +99,7 @@ File: bk12.clo 2018/09/03 v1.4i Standard LaTeX file (size option)
 \enumdim=\dimen123
 \concolwidth=\dimen124
 \stempbox=\box51
-) ("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/lm\lmodern.sty"
+) (/usr/share/texmf/tex/latex/lm/lmodern.sty
 Package: lmodern 2009/10/30 v1.6 Latin Modern Fonts
 LaTeX Font Info:    Overwriting symbol font `operators' in version `normal'
 (Font)                  OT1/cmr/m/n --> OT1/lmr/m/n on input line 22.
@@ -131,40 +133,29 @@ LaTeX Font Info:    Overwriting math alphabet `\mathit' in version `bold'
 (Font)                  OT1/cmr/bx/it --> OT1/lmr/bx/it on input line 37.
 LaTeX Font Info:    Overwriting math alphabet `\mathtt' in version `bold'
 (Font)                  OT1/cmtt/m/n --> OT1/lmtt/m/n on input line 38.
-)
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsfonts\amssymb.s
-ty"
+) (/usr/share/texlive/texmf-dist/tex/latex/amsfonts/amssymb.sty
 Package: amssymb 2013/01/14 v3.01 AMS font symbols
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsfonts\amsfonts.
-sty"
+(/usr/share/texlive/texmf-dist/tex/latex/amsfonts/amsfonts.sty
 Package: amsfonts 2013/01/14 v3.01 Basic AMSFonts support
 \@emptytoks=\toks14
 \symAMSa=\mathgroup4
 \symAMSb=\mathgroup5
 LaTeX Font Info:    Overwriting math alphabet `\mathfrak' in version `bold'
 (Font)                  U/euf/m/n --> U/euf/b/n on input line 106.
-))
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsmath\amsmath.st
-y"
+)) (/usr/share/texlive/texmf-dist/tex/latex/amsmath/amsmath.sty
 Package: amsmath 2018/12/01 v2.17b AMS math features
 \@mathmargin=\skip71
 For additional information on amsmath, use the `?' option.
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsmath\amstext.st
-y"
+(/usr/share/texlive/texmf-dist/tex/latex/amsmath/amstext.sty
 Package: amstext 2000/06/29 v2.01 AMS text
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsmath\amsgen.sty
-"
+(/usr/share/texlive/texmf-dist/tex/latex/amsmath/amsgen.sty
 File: amsgen.sty 1999/11/30 v2.0 generic functions
 \@emptytoks=\toks15
 \ex@=\dimen125
-)) ("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsmath\amsbsy.
-sty"
+)) (/usr/share/texlive/texmf-dist/tex/latex/amsmath/amsbsy.sty
 Package: amsbsy 1999/11/29 v1.2d Bold Symbols
 \pmbraise@=\dimen126
-) ("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/amsmath\amsopn.s
-ty"
+) (/usr/share/texlive/texmf-dist/tex/latex/amsmath/amsopn.sty
 Package: amsopn 2016/03/08 v2.02 operator names
 )
 \inf@bad=\count91
@@ -204,298 +195,452 @@ LaTeX Font Info:    Redeclaring font encoding OMS on input line 730.
 \mathdisplay@stack=\toks19
 LaTeX Info: Redefining \[ on input line 2844.
 LaTeX Info: Redefining \] on input line 2845.
-)
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/generic/ifxetex\ifxetex.
-sty"
+) (/usr/share/texlive/texmf-dist/tex/generic/ifxetex/ifxetex.sty
 Package: ifxetex 2010/09/12 v0.6 Provides ifxetex conditional
-)
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/generic/oberdiek\ifluate
-x.sty"
+) (/usr/share/texlive/texmf-dist/tex/generic/oberdiek/ifluatex.sty
 Package: ifluatex 2016/05/16 v1.4 Provides the ifluatex switch (HO)
 Package ifluatex Info: LuaTeX not detected.
-) ("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/base\fixltx2e.st
-y"
-Package: fixltx2e 2016/12/29 v2.1a fixes to LaTeX (obsolete)
-Applying: [2015/01/01] Old fixltx2e package on input line 46.
-
-Package fixltx2e Warning: fixltx2e is not required with releases after 2015
-(fixltx2e)                All fixes are now in the LaTeX kernel.
-(fixltx2e)                See the latexrelease package for details.
-
-Already applied: [0000/00/00] Old fixltx2e package on input line 53.
-)
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/xelatex/mathspec\mathspe
-c.sty"
-Package: mathspec 2016/12/22 v0.2b LaTeX Package (Mathematics font selection fo
-r XeLaTeX)
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/etoolbox\etoolbox.
-sty"
-Package: etoolbox 2018/08/19 v2.5f e-TeX tools for LaTeX (JAW)
-\etb@tempcnta=\count103
-)
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/fontspec\fontspec.
-sty"
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/l3packages/xparse\
-xparse.sty" ("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/l3kern
-el\expl3.sty"
-Package: expl3 2019-11-07 L3 programming layer (loader) 
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/l3kernel\expl3-cod
-e.tex"
-Package: expl3 2019-11-07 L3 programming layer (code)
-\c_max_int=\count104
-\l_tmpa_int=\count105
-\l_tmpb_int=\count106
-\g_tmpa_int=\count107
-\g_tmpb_int=\count108
-\l__seq_internal_a_int=\count109
-\l__seq_internal_b_int=\count110
-\g__kernel_prg_map_int=\count111
-\c__ior_term_noprompt_ior=\count112
-\c_log_iow=\count113
-\l_iow_line_count_int=\count114
-\l__iow_line_target_int=\count115
-\l__iow_one_indent_int=\count116
-\l__iow_indent_int=\count117
-\c_zero_dim=\dimen134
-\c_max_dim=\dimen135
-\l_tmpa_dim=\dimen136
-\l_tmpb_dim=\dimen137
-\g_tmpa_dim=\dimen138
-\g_tmpb_dim=\dimen139
-\c_zero_skip=\skip74
-\c_max_skip=\skip75
-\l_tmpa_skip=\skip76
-\l_tmpb_skip=\skip77
-\g_tmpa_skip=\skip78
-\g_tmpb_skip=\skip79
-\c_zero_muskip=\muskip11
-\c_max_muskip=\muskip12
-\l_tmpa_muskip=\muskip13
-\l_tmpb_muskip=\muskip14
-\g_tmpa_muskip=\muskip15
-\g_tmpb_muskip=\muskip16
-\l_keys_choice_int=\count118
-\l__intarray_loop_int=\count119
-\c__intarray_sp_dim=\dimen140
-\g__intarray_font_int=\count120
-\c__fp_leading_shift_int=\count121
-\c__fp_middle_shift_int=\count122
-\c__fp_trailing_shift_int=\count123
-\c__fp_big_leading_shift_int=\count124
-\c__fp_big_middle_shift_int=\count125
-\c__fp_big_trailing_shift_int=\count126
-\c__fp_Bigg_leading_shift_int=\count127
-\c__fp_Bigg_middle_shift_int=\count128
-\c__fp_Bigg_trailing_shift_int=\count129
-\g__fp_array_int=\count130
-\l__fp_array_loop_int=\count131
-\l__sort_length_int=\count132
-\l__sort_min_int=\count133
-\l__sort_top_int=\count134
-\l__sort_max_int=\count135
-\l__sort_true_max_int=\count136
-\l__sort_block_int=\count137
-\l__sort_begin_int=\count138
-\l__sort_end_int=\count139
-\l__sort_A_int=\count140
-\l__sort_B_int=\count141
-\l__sort_C_int=\count142
-\l__str_internal_int=\count143
-\l__tl_analysis_normal_int=\count144
-\l__tl_analysis_index_int=\count145
-\l__tl_analysis_nesting_int=\count146
-\l__tl_analysis_type_int=\count147
-\l__regex_internal_a_int=\count148
-\l__regex_internal_b_int=\count149
-\l__regex_internal_c_int=\count150
-\l__regex_balance_int=\count151
-\l__regex_group_level_int=\count152
-\l__regex_mode_int=\count153
-\c__regex_cs_in_class_mode_int=\count154
-\c__regex_cs_mode_int=\count155
-\l__regex_catcodes_int=\count156
-\l__regex_default_catcodes_int=\count157
-\c__regex_catcode_L_int=\count158
-\c__regex_catcode_O_int=\count159
-\c__regex_catcode_A_int=\count160
-\c__regex_all_catcodes_int=\count161
-\l__regex_show_lines_int=\count162
-\l__regex_min_state_int=\count163
-\l__regex_max_state_int=\count164
-\l__regex_left_state_int=\count165
-\l__regex_right_state_int=\count166
-\l__regex_capturing_group_int=\count167
-\l__regex_min_pos_int=\count168
-\l__regex_max_pos_int=\count169
-\l__regex_curr_pos_int=\count170
-\l__regex_start_pos_int=\count171
-\l__regex_success_pos_int=\count172
-\l__regex_curr_char_int=\count173
-\l__regex_curr_catcode_int=\count174
-\l__regex_last_char_int=\count175
-\l__regex_case_changed_char_int=\count176
-\l__regex_curr_state_int=\count177
-\l__regex_step_int=\count178
-\l__regex_min_active_int=\count179
-\l__regex_max_active_int=\count180
-\l__regex_replacement_csnames_int=\count181
-\l__regex_match_count_int=\count182
-\l__regex_min_submatch_int=\count183
-\l__regex_submatch_int=\count184
-\l__regex_zeroth_submatch_int=\count185
-\g__regex_trace_regex_int=\count186
-\c_empty_box=\box54
-\l_tmpa_box=\box55
-\l_tmpb_box=\box56
-\g_tmpa_box=\box57
-\g_tmpb_box=\box58
-\l__box_top_dim=\dimen141
-\l__box_bottom_dim=\dimen142
-\l__box_left_dim=\dimen143
-\l__box_right_dim=\dimen144
-\l__box_top_new_dim=\dimen145
-\l__box_bottom_new_dim=\dimen146
-\l__box_left_new_dim=\dimen147
-\l__box_right_new_dim=\dimen148
-\l__box_internal_box=\box59
-\l__coffin_internal_box=\box60
-\l__coffin_internal_dim=\dimen149
-\l__coffin_offset_x_dim=\dimen150
-\l__coffin_offset_y_dim=\dimen151
-\l__coffin_x_dim=\dimen152
-\l__coffin_y_dim=\dimen153
-\l__coffin_x_prime_dim=\dimen154
-\l__coffin_y_prime_dim=\dimen155
-\c_empty_coffin=\box61
-\l__coffin_aligned_coffin=\box62
-\l__coffin_aligned_internal_coffin=\box63
-\l_tmpa_coffin=\box64
-\l_tmpb_coffin=\box65
-\g_tmpa_coffin=\box66
-\g_tmpb_coffin=\box67
-\l__coffin_bounding_shift_dim=\dimen156
-\l__coffin_left_corner_dim=\dimen157
-\l__coffin_right_corner_dim=\dimen158
-\l__coffin_bottom_corner_dim=\dimen159
-\l__coffin_top_corner_dim=\dimen160
-\l__coffin_scaled_total_height_dim=\dimen161
-\l__coffin_scaled_width_dim=\dimen162
-\c__coffin_empty_coffin=\box68
-\l__coffin_display_coffin=\box69
-\l__coffin_display_coord_coffin=\box70
-\l__coffin_display_pole_coffin=\box71
-\l__coffin_display_offset_dim=\dimen163
-\l__coffin_display_x_dim=\dimen164
-\l__coffin_display_y_dim=\dimen165
-\g__char_data_ior=\read1
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/l3kernel\l3depreca
-tion.def"
-File: l3deprecation.def 2019-04-06 v L3 Deprecated functions
-))
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/l3backend\l3backen
-d-xdvipdfmx.def"
-File: l3backend-xdvipdfmx.def 2019-04-06 L3 backend support: xdvipdfmx
-\g__graphics_track_int=\count187
-\l__pdf_internal_box=\box72
-\g__pdf_backend_object_int=\count188
-\g__pdf_backend_annotation_int=\count189
-))
-Package: xparse 2019-10-11 L3 Experimental document command parser
-\l__xparse_current_arg_int=\count190
-\g__xparse_grabber_int=\count191
-\l__xparse_m_args_int=\count192
-\l__xparse_v_nesting_int=\count193
-)
-Package: fontspec 2019/03/15 v2.7c Font selection for XeLaTeX and LuaLaTeX
-
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/fontspec\fontspec-
-xetex.sty"
-Package: fontspec-xetex 2019/03/15 v2.7c Font selection for XeLaTeX and LuaLaTe
-X
-\l__fontspec_script_int=\count194
-\l__fontspec_language_int=\count195
-\l__fontspec_strnum_int=\count196
-\l__fontspec_tmp_int=\count197
-\l__fontspec_tmpa_int=\count198
-\l__fontspec_tmpb_int=\count199
-\l__fontspec_tmpc_int=\count266
-\l__fontspec_em_int=\count267
-\l__fontspec_emdef_int=\count268
-\l__fontspec_strong_int=\count269
-\l__fontspec_strongdef_int=\count270
-\l__fontspec_tmpa_dim=\dimen166
-\l__fontspec_tmpb_dim=\dimen167
-\l__fontspec_tmpc_dim=\dimen168
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/base\fontenc.sty"
+) (/usr/share/texlive/texmf-dist/tex/latex/base/fontenc.sty
 Package: fontenc 2018/08/11 v2.0j Standard LaTeX package
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/base\tuenc.def"
-File: tuenc.def 2018/08/11 v2.0j Standard LaTeX file
-LaTeX Font Info:    Redeclaring font encoding TU on input line 82.
+(/usr/share/texlive/texmf-dist/tex/latex/base/t1enc.def
+File: t1enc.def 2018/08/11 v2.0j Standard LaTeX file
+LaTeX Font Info:    Redeclaring font encoding T1 on input line 48.
+)) (/usr/share/texlive/texmf-dist/tex/latex/base/inputenc.sty
+Package: inputenc 2018/08/11 v1.3c Input encoding file
+\inpenc@prehook=\toks20
+\inpenc@posthook=\toks21
+) (/usr/share/texlive/texmf-dist/tex/latex/base/textcomp.sty
+Package: textcomp 2018/08/11 v2.0j Standard LaTeX package
+Package textcomp Info: Sub-encoding information:
+(textcomp)               5 = only ISO-Adobe without \textcurrency
+(textcomp)               4 = 5 + \texteuro
+(textcomp)               3 = 4 + \textohm
+(textcomp)               2 = 3 + \textestimated + \textcurrency
+(textcomp)               1 = TS1 - \textcircled - \t
+(textcomp)               0 = TS1 (full)
+(textcomp)             Font families with sub-encoding setting implement
+(textcomp)             only a restricted character set as indicated.
+(textcomp)             Family '?' is the default used for unknown fonts.
+(textcomp)             See the documentation for details.
+Package textcomp Info: Setting ? sub-encoding to TS1/1 on input line 79.
+(/usr/share/texlive/texmf-dist/tex/latex/base/ts1enc.def
+File: ts1enc.def 2001/06/05 v3.0e (jk/car/fm) Standard LaTeX file
+Now handling font encoding TS1 ...
+... processing UTF-8 mapping file for font encoding TS1
+(/usr/share/texlive/texmf-dist/tex/latex/base/ts1enc.dfu
+File: ts1enc.dfu 2018/10/05 v1.2f UTF-8 support for inputenc
+   defining Unicode char U+00A2 (decimal 162)
+   defining Unicode char U+00A3 (decimal 163)
+   defining Unicode char U+00A4 (decimal 164)
+   defining Unicode char U+00A5 (decimal 165)
+   defining Unicode char U+00A6 (decimal 166)
+   defining Unicode char U+00A7 (decimal 167)
+   defining Unicode char U+00A8 (decimal 168)
+   defining Unicode char U+00A9 (decimal 169)
+   defining Unicode char U+00AA (decimal 170)
+   defining Unicode char U+00AC (decimal 172)
+   defining Unicode char U+00AE (decimal 174)
+   defining Unicode char U+00AF (decimal 175)
+   defining Unicode char U+00B0 (decimal 176)
+   defining Unicode char U+00B1 (decimal 177)
+   defining Unicode char U+00B2 (decimal 178)
+   defining Unicode char U+00B3 (decimal 179)
+   defining Unicode char U+00B4 (decimal 180)
+   defining Unicode char U+00B5 (decimal 181)
+   defining Unicode char U+00B6 (decimal 182)
+   defining Unicode char U+00B7 (decimal 183)
+   defining Unicode char U+00B9 (decimal 185)
+   defining Unicode char U+00BA (decimal 186)
+   defining Unicode char U+00BC (decimal 188)
+   defining Unicode char U+00BD (decimal 189)
+   defining Unicode char U+00BE (decimal 190)
+   defining Unicode char U+00D7 (decimal 215)
+   defining Unicode char U+00F7 (decimal 247)
+   defining Unicode char U+0192 (decimal 402)
+   defining Unicode char U+02C7 (decimal 711)
+   defining Unicode char U+02D8 (decimal 728)
+   defining Unicode char U+02DD (decimal 733)
+   defining Unicode char U+0E3F (decimal 3647)
+   defining Unicode char U+2016 (decimal 8214)
+   defining Unicode char U+2020 (decimal 8224)
+   defining Unicode char U+2021 (decimal 8225)
+   defining Unicode char U+2022 (decimal 8226)
+   defining Unicode char U+2030 (decimal 8240)
+   defining Unicode char U+2031 (decimal 8241)
+   defining Unicode char U+203B (decimal 8251)
+   defining Unicode char U+203D (decimal 8253)
+   defining Unicode char U+2044 (decimal 8260)
+   defining Unicode char U+204E (decimal 8270)
+   defining Unicode char U+2052 (decimal 8274)
+   defining Unicode char U+20A1 (decimal 8353)
+   defining Unicode char U+20A4 (decimal 8356)
+   defining Unicode char U+20A6 (decimal 8358)
+   defining Unicode char U+20A9 (decimal 8361)
+   defining Unicode char U+20AB (decimal 8363)
+   defining Unicode char U+20AC (decimal 8364)
+   defining Unicode char U+20B1 (decimal 8369)
+   defining Unicode char U+2103 (decimal 8451)
+   defining Unicode char U+2116 (decimal 8470)
+   defining Unicode char U+2117 (decimal 8471)
+   defining Unicode char U+211E (decimal 8478)
+   defining Unicode char U+2120 (decimal 8480)
+   defining Unicode char U+2122 (decimal 8482)
+   defining Unicode char U+2126 (decimal 8486)
+   defining Unicode char U+2127 (decimal 8487)
+   defining Unicode char U+212E (decimal 8494)
+   defining Unicode char U+2190 (decimal 8592)
+   defining Unicode char U+2191 (decimal 8593)
+   defining Unicode char U+2192 (decimal 8594)
+   defining Unicode char U+2193 (decimal 8595)
+   defining Unicode char U+2329 (decimal 9001)
+   defining Unicode char U+232A (decimal 9002)
+   defining Unicode char U+2422 (decimal 9250)
+   defining Unicode char U+25E6 (decimal 9702)
+   defining Unicode char U+25EF (decimal 9711)
+   defining Unicode char U+266A (decimal 9834)
+   defining Unicode char U+FEFF (decimal 65279)
 ))
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/fontspec\fontspec.
-cfg")
-LaTeX Info: Redefining \itshape on input line 4051.
-LaTeX Info: Redefining \slshape on input line 4056.
-LaTeX Info: Redefining \scshape on input line 4061.
-LaTeX Info: Redefining \upshape on input line 4066.
-LaTeX Info: Redefining \em on input line 4096.
-LaTeX Info: Redefining \emph on input line 4121.
-))
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/latex/xkeyval\xkeyval.st
-y"
-Package: xkeyval 2014/12/03 v2.7a package option processing (HA)
+LaTeX Info: Redefining \oldstylenums on input line 334.
+Package textcomp Info: Setting cmr sub-encoding to TS1/0 on input line 349.
+Package textcomp Info: Setting cmss sub-encoding to TS1/0 on input line 350.
+Package textcomp Info: Setting cmtt sub-encoding to TS1/0 on input line 351.
+Package textcomp Info: Setting cmvtt sub-encoding to TS1/0 on input line 352.
+Package textcomp Info: Setting cmbr sub-encoding to TS1/0 on input line 353.
+Package textcomp Info: Setting cmtl sub-encoding to TS1/0 on input line 354.
+Package textcomp Info: Setting ccr sub-encoding to TS1/0 on input line 355.
+Package textcomp Info: Setting ptm sub-encoding to TS1/4 on input line 356.
+Package textcomp Info: Setting pcr sub-encoding to TS1/4 on input line 357.
+Package textcomp Info: Setting phv sub-encoding to TS1/4 on input line 358.
+Package textcomp Info: Setting ppl sub-encoding to TS1/3 on input line 359.
+Package textcomp Info: Setting pag sub-encoding to TS1/4 on input line 360.
+Package textcomp Info: Setting pbk sub-encoding to TS1/4 on input line 361.
+Package textcomp Info: Setting pnc sub-encoding to TS1/4 on input line 362.
+Package textcomp Info: Setting pzc sub-encoding to TS1/4 on input line 363.
+Package textcomp Info: Setting bch sub-encoding to TS1/4 on input line 364.
+Package textcomp Info: Setting put sub-encoding to TS1/5 on input line 365.
+Package textcomp Info: Setting uag sub-encoding to TS1/5 on input line 366.
+Package textcomp Info: Setting ugq sub-encoding to TS1/5 on input line 367.
+Package textcomp Info: Setting ul8 sub-encoding to TS1/4 on input line 368.
+Package textcomp Info: Setting ul9 sub-encoding to TS1/4 on input line 369.
+Package textcomp Info: Setting augie sub-encoding to TS1/5 on input line 370.
+Package textcomp Info: Setting dayrom sub-encoding to TS1/3 on input line 371.
+Package textcomp Info: Setting dayroms sub-encoding to TS1/3 on input line 372.
 
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/generic/xkeyval\xkeyval.
-tex"
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/generic/xkeyval\xkvutils
-.tex"
-\XKV@toks=\toks20
-\XKV@tempa@toks=\toks21
+Package textcomp Info: Setting pxr sub-encoding to TS1/0 on input line 373.
+Package textcomp Info: Setting pxss sub-encoding to TS1/0 on input line 374.
+Package textcomp Info: Setting pxtt sub-encoding to TS1/0 on input line 375.
+Package textcomp Info: Setting txr sub-encoding to TS1/0 on input line 376.
+Package textcomp Info: Setting txss sub-encoding to TS1/0 on input line 377.
+Package textcomp Info: Setting txtt sub-encoding to TS1/0 on input line 378.
+Package textcomp Info: Setting lmr sub-encoding to TS1/0 on input line 379.
+Package textcomp Info: Setting lmdh sub-encoding to TS1/0 on input line 380.
+Package textcomp Info: Setting lmss sub-encoding to TS1/0 on input line 381.
+Package textcomp Info: Setting lmssq sub-encoding to TS1/0 on input line 382.
+Package textcomp Info: Setting lmvtt sub-encoding to TS1/0 on input line 383.
+Package textcomp Info: Setting lmtt sub-encoding to TS1/0 on input line 384.
+Package textcomp Info: Setting qhv sub-encoding to TS1/0 on input line 385.
+Package textcomp Info: Setting qag sub-encoding to TS1/0 on input line 386.
+Package textcomp Info: Setting qbk sub-encoding to TS1/0 on input line 387.
+Package textcomp Info: Setting qcr sub-encoding to TS1/0 on input line 388.
+Package textcomp Info: Setting qcs sub-encoding to TS1/0 on input line 389.
+Package textcomp Info: Setting qpl sub-encoding to TS1/0 on input line 390.
+Package textcomp Info: Setting qtm sub-encoding to TS1/0 on input line 391.
+Package textcomp Info: Setting qzc sub-encoding to TS1/0 on input line 392.
+Package textcomp Info: Setting qhvc sub-encoding to TS1/0 on input line 393.
+Package textcomp Info: Setting futs sub-encoding to TS1/4 on input line 394.
+Package textcomp Info: Setting futx sub-encoding to TS1/4 on input line 395.
+Package textcomp Info: Setting futj sub-encoding to TS1/4 on input line 396.
+Package textcomp Info: Setting hlh sub-encoding to TS1/3 on input line 397.
+Package textcomp Info: Setting hls sub-encoding to TS1/3 on input line 398.
+Package textcomp Info: Setting hlst sub-encoding to TS1/3 on input line 399.
+Package textcomp Info: Setting hlct sub-encoding to TS1/5 on input line 400.
+Package textcomp Info: Setting hlx sub-encoding to TS1/5 on input line 401.
+Package textcomp Info: Setting hlce sub-encoding to TS1/5 on input line 402.
+Package textcomp Info: Setting hlcn sub-encoding to TS1/5 on input line 403.
+Package textcomp Info: Setting hlcw sub-encoding to TS1/5 on input line 404.
+Package textcomp Info: Setting hlcf sub-encoding to TS1/5 on input line 405.
+Package textcomp Info: Setting pplx sub-encoding to TS1/3 on input line 406.
+Package textcomp Info: Setting pplj sub-encoding to TS1/3 on input line 407.
+Package textcomp Info: Setting ptmx sub-encoding to TS1/4 on input line 408.
+Package textcomp Info: Setting ptmj sub-encoding to TS1/4 on input line 409.
+) (/usr/share/texlive/texmf-dist/tex/latex/upquote/upquote.sty
+Package: upquote 2012/04/19 v1.3 upright-quote and grave-accent glyphs in verba
+tim
+) (/usr/share/texlive/texmf-dist/tex/latex/microtype/microtype.sty
+Package: microtype 2019/02/28 v2.7b Micro-typographical refinements (RS)
+(/usr/share/texlive/texmf-dist/tex/latex/graphics/keyval.sty
+Package: keyval 2014/10/28 v1.15 key=value parser (DPC)
+\KV@toks@=\toks22
+)
+\MT@toks=\toks23
+\MT@count=\count103
+LaTeX Info: Redefining \textls on input line 790.
+\MT@outer@kern=\dimen134
+LaTeX Info: Redefining \textmicrotypecontext on input line 1336.
+\MT@listname@count=\count104
+(/usr/share/texlive/texmf-dist/tex/latex/microtype/microtype-pdftex.def
+File: microtype-pdftex.def 2019/02/28 v2.7b Definitions specific to pdftex (RS)
 
-("C:\Users\elise\AppData\Local\Programs\MiKTeX 2.9\tex/generic/xkeyval\keyval.t
-ex"))
-\XKV@depth=\count271
-File: xkeyval.tex 2014/12/03 v2.7a key=value parser (HA)
+LaTeX Info: Redefining \lsstyle on input line 914.
+LaTeX Info: Redefining \lslig on input line 914.
+\MT@outer@space=\skip74
+)
+Package microtype Info: Loading configuration file microtype.cfg.
+(/usr/share/texlive/texmf-dist/tex/latex/microtype/microtype.cfg
+File: microtype.cfg 2019/02/28 v2.7b microtype main configuration file (RS)
+)) (/usr/share/texlive/texmf-dist/tex/latex/parskip/parskip.sty
+Package: parskip 2019-01-16 v2.0c non-zero parskip adjustments
+(/usr/share/texlive/texmf-dist/tex/latex/oberdiek/kvoptions.sty
+Package: kvoptions 2016/05/16 v3.12 Key value format for package options (HO)
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/ltxcmds.sty
+Package: ltxcmds 2016/05/16 v1.23 LaTeX kernel commands for general use (HO)
+) (/usr/share/texlive/texmf-dist/tex/generic/oberdiek/kvsetkeys.sty
+Package: kvsetkeys 2016/05/16 v1.17 Key value parser (HO)
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/infwarerr.sty
+Package: infwarerr 2016/05/16 v1.4 Providing info/warning/error messages (HO)
+) (/usr/share/texlive/texmf-dist/tex/generic/oberdiek/etexcmds.sty
+Package: etexcmds 2016/05/16 v1.6 Avoid name clashes with e-TeX commands (HO)
+))) (/usr/share/texlive/texmf-dist/tex/latex/etoolbox/etoolbox.sty
+Package: etoolbox 2018/08/19 v2.5f e-TeX tools for LaTeX (JAW)
+\etb@tempcnta=\count105
+)) (/usr/share/texlive/texmf-dist/tex/latex/xcolor/xcolor.sty
+Package: xcolor 2016/05/11 v2.12 LaTeX color extensions (UK)
+(/usr/share/texlive/texmf-dist/tex/latex/graphics-cfg/color.cfg
+File: color.cfg 2016/01/02 v1.6 sample color configuration
+)
+Package xcolor Info: Driver file: pdftex.def on input line 225.
+(/usr/share/texlive/texmf-dist/tex/latex/graphics-def/pdftex.def
+File: pdftex.def 2018/01/08 v1.0l Graphics/color driver for pdftex
+)
+Package xcolor Info: Model `cmy' substituted by `cmy0' on input line 1348.
+Package xcolor Info: Model `hsb' substituted by `rgb' on input line 1352.
+Package xcolor Info: Model `RGB' extended on input line 1364.
+Package xcolor Info: Model `HTML' substituted by `rgb' on input line 1366.
+Package xcolor Info: Model `Hsb' substituted by `hsb' on input line 1367.
+Package xcolor Info: Model `tHsb' substituted by `hsb' on input line 1368.
+Package xcolor Info: Model `HSB' substituted by `hsb' on input line 1369.
+Package xcolor Info: Model `Gray' substituted by `gray' on input line 1370.
+Package xcolor Info: Model `wave' substituted by `hsb' on input line 1371.
+(/usr/share/texlive/texmf-dist/tex/latex/graphics/dvipsnam.def
+File: dvipsnam.def 2016/06/17 v3.0m Driver-dependent file (DPC,SPQR)
+) (/usr/share/texlive/texmf-dist/tex/latex/xcolor/svgnam.def
+File: svgnam.def 2016/05/11 v2.12 Predefined colors according to SVG 1.1 (UK)
+) (/usr/share/texlive/texmf-dist/tex/latex/xcolor/x11nam.def
+File: x11nam.def 2016/05/11 v2.12 Predefined colors according to Unix/X11 (UK)
+)) (/usr/share/texlive/texmf-dist/tex/latex/xurl/xurl.sty
+Package: xurl 2018/12/23 v 0.07 modify URL breaks
+(/usr/share/texlive/texmf-dist/tex/latex/url/url.sty
+\Urlmuskip=\muskip11
+Package: url 2013/09/16  ver 3.4  Verb mode for urls, etc.
+)) (/usr/share/texlive/texmf-dist/tex/latex/oberdiek/bookmark.sty
+Package: bookmark 2016/05/17 v1.26 PDF bookmarks (HO)
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/pdfescape.sty
+Package: pdfescape 2016/05/16 v1.14 Implements pdfTeX's escape features (HO)
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/pdftexcmds.sty
+Package: pdftexcmds 2018/09/10 v0.29 Utility functions of pdfTeX for LuaTeX (HO
+)
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/ifpdf.sty
+Package: ifpdf 2018/09/07 v3.3 Provides the ifpdf switch
+)
+Package pdftexcmds Info: LuaTeX not detected.
+Package pdftexcmds Info: \pdf@primitive is available.
+Package pdftexcmds Info: \pdf@ifprimitive is available.
+Package pdftexcmds Info: \pdfdraftmode found.
+)) (/usr/share/texlive/texmf-dist/tex/generic/oberdiek/ifvtex.sty
+Package: ifvtex 2016/05/16 v1.6 Detect VTeX and its facilities (HO)
+Package ifvtex Info: VTeX not detected.
+) (/usr/share/texlive/texmf-dist/tex/latex/hyperref/hyperref.sty
+Package: hyperref 2018/11/30 v6.88e Hypertext links for LaTeX
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/hobsub-hyperref.sty
+Package: hobsub-hyperref 2016/05/16 v1.14 Bundle oberdiek, subset hyperref (HO)
+
+(/usr/share/texlive/texmf-dist/tex/generic/oberdiek/hobsub-generic.sty
+Package: hobsub-generic 2016/05/16 v1.14 Bundle oberdiek, subset generic (HO)
+Package: hobsub 2016/05/16 v1.14 Construct package bundles (HO)
+Package hobsub Info: Skipping package `infwarerr' (already loaded).
+Package hobsub Info: Skipping package `ltxcmds' (already loaded).
+Package hobsub Info: Skipping package `ifluatex' (already loaded).
+Package hobsub Info: Skipping package `ifvtex' (already loaded).
+Package: intcalc 2016/05/16 v1.2 Expandable calculations with integers (HO)
+Package hobsub Info: Skipping package `ifpdf' (already loaded).
+Package hobsub Info: Skipping package `etexcmds' (already loaded).
+Package hobsub Info: Skipping package `kvsetkeys' (already loaded).
+Package: kvdefinekeys 2016/05/16 v1.4 Define keys (HO)
+Package hobsub Info: Skipping package `pdftexcmds' (already loaded).
+Package hobsub Info: Skipping package `pdfescape' (already loaded).
+Package: bigintcalc 2016/05/16 v1.4 Expandable calculations on big integers (HO
+)
+Package: bitset 2016/05/16 v1.2 Handle bit-vector datatype (HO)
+Package: uniquecounter 2016/05/16 v1.3 Provide unlimited unique counter (HO)
+)
+Package hobsub Info: Skipping package `hobsub' (already loaded).
+Package: letltxmacro 2016/05/16 v1.5 Let assignment for LaTeX macros (HO)
+Package: hopatch 2016/05/16 v1.3 Wrapper for package hooks (HO)
+Package: xcolor-patch 2016/05/16 xcolor patch
+Package: atveryend 2016/05/16 v1.9 Hooks at the very end of document (HO)
+Package: atbegshi 2016/06/09 v1.18 At begin shipout hook (HO)
+Package: refcount 2016/05/16 v3.5 Data extraction from label references (HO)
+Package: hycolor 2016/05/16 v1.8 Color options for hyperref/bookmark (HO)
+) (/usr/share/texlive/texmf-dist/tex/latex/oberdiek/auxhook.sty
+Package: auxhook 2016/05/16 v1.4 Hooks for auxiliary files (HO)
+)
+\@linkdim=\dimen135
+\Hy@linkcounter=\count106
+\Hy@pagecounter=\count107
+(/usr/share/texlive/texmf-dist/tex/latex/hyperref/pd1enc.def
+File: pd1enc.def 2018/11/30 v6.88e Hyperref: PDFDocEncoding definition (HO)
+Now handling font encoding PD1 ...
+... no UTF-8 mapping file for font encoding PD1
+)
+\Hy@SavedSpaceFactor=\count108
+(/usr/share/texlive/texmf-dist/tex/latex/latexconfig/hyperref.cfg
+File: hyperref.cfg 2002/06/06 v1.2 hyperref configuration of TeXLive
+)
+Package hyperref Info: Option `unicode' set `true' on input line 4393.
+(/usr/share/texlive/texmf-dist/tex/latex/hyperref/puenc.def
+File: puenc.def 2018/11/30 v6.88e Hyperref: PDF Unicode definition (HO)
+Now handling font encoding PU ...
+... no UTF-8 mapping file for font encoding PU
+)
+Package hyperref Info: Hyper figures OFF on input line 4519.
+Package hyperref Info: Link nesting OFF on input line 4524.
+Package hyperref Info: Hyper index ON on input line 4527.
+Package hyperref Info: Plain pages OFF on input line 4534.
+Package hyperref Info: Backreferencing OFF on input line 4539.
+Package hyperref Info: Implicit mode ON; LaTeX internals redefined.
+Package hyperref Info: Bookmarks ON on input line 4772.
+\c@Hy@tempcnt=\count109
+LaTeX Info: Redefining \url on input line 5125.
+\XeTeXLinkMargin=\dimen136
+\Fld@menulength=\count110
+\Field@Width=\dimen137
+\Fld@charsize=\dimen138
+Package hyperref Info: Hyper figures OFF on input line 6380.
+Package hyperref Info: Link nesting OFF on input line 6385.
+Package hyperref Info: Hyper index ON on input line 6388.
+Package hyperref Info: backreferencing OFF on input line 6395.
+Package hyperref Info: Link coloring OFF on input line 6400.
+Package hyperref Info: Link coloring with OCG OFF on input line 6405.
+Package hyperref Info: PDF/A mode OFF on input line 6410.
+LaTeX Info: Redefining \ref on input line 6450.
+LaTeX Info: Redefining \pageref on input line 6454.
+\Hy@abspage=\count111
+\c@Item=\count112
+\c@Hfootnote=\count113
+)
+Package hyperref Info: Driver (autodetected): hpdftex.
+(/usr/share/texlive/texmf-dist/tex/latex/hyperref/hpdftex.def
+File: hpdftex.def 2018/11/30 v6.88e Hyperref driver for pdfTeX
+\Fld@listcount=\count114
+\c@bookmark@seq@number=\count115
+(/usr/share/texlive/texmf-dist/tex/latex/oberdiek/rerunfilecheck.sty
+Package: rerunfilecheck 2016/05/16 v1.8 Rerun checks for auxiliary files (HO)
+Package uniquecounter Info: New unique counter `rerunfilecheck' on input line 2
+82.
+)
+\Hy@SectionHShift=\skip75
+) (/usr/share/texlive/texmf-dist/tex/latex/oberdiek/bkm-pdftex.def
+File: bkm-pdftex.def 2016/05/17 v1.26 bookmark driver for pdfTeX (HO)
+\BKM@id=\count116
 ))
-\c@eu@=\count272
-\c@eu@i=\count273
-\c@mkern=\count274
+Package hyperref Info: Option `colorlinks' set `true' on input line 48.
+(/usr/share/texlive/texmf-dist/tex/latex/fancyvrb/fancyvrb.sty
+Package: fancyvrb 2019/01/15
+Style option: `fancyvrb' v3.2a <2019/01/15> (tvz)
+\FV@CodeLineNo=\count117
+\FV@InFile=\read1
+\FV@TabBox=\box54
+\c@FancyVerbLine=\count118
+\FV@StepNumber=\count119
+\FV@OutFile=\write3
+) (/usr/share/texlive/texmf-dist/tex/latex/framed/framed.sty
+Package: framed 2011/10/22 v 0.96: framed or shaded text with page breaks
+\OuterFrameSep=\skip76
+\fb@frw=\dimen139
+\fb@frh=\dimen140
+\FrameRule=\dimen141
+\FrameSep=\dimen142
+) (/usr/share/texlive/texmf-dist/tex/latex/tools/longtable.sty
+Package: longtable 2014/10/28 v4.11 Multi-page Table package (DPC)+ FMi change
+\LTleft=\skip77
+\LTright=\skip78
+\LTpre=\skip79
+\LTpost=\skip80
+\LTchunksize=\count120
+\LTcapwidth=\dimen143
+\LT@head=\box55
+\LT@firsthead=\box56
+\LT@foot=\box57
+\LT@lastfoot=\box58
+\LT@cols=\count121
+\LT@rows=\count122
+\c@LT@tables=\count123
+\c@LT@chunks=\count124
+\LT@p@ftn=\toks24
+) (/usr/share/texlive/texmf-dist/tex/latex/booktabs/booktabs.sty
+Package: booktabs 2016/04/27 v1.618033 publication quality tables
+\heavyrulewidth=\dimen144
+\lightrulewidth=\dimen145
+\cmidrulewidth=\dimen146
+\belowrulesep=\dimen147
+\belowbottomsep=\dimen148
+\aboverulesep=\dimen149
+\abovetopsep=\dimen150
+\cmidrulesep=\dimen151
+\cmidrulekern=\dimen152
+\defaultaddspace=\dimen153
+\@cmidla=\count125
+\@cmidlb=\count126
+\@aboverulesep=\dimen154
+\@belowrulesep=\dimen155
+\@thisruleclass=\count127
+\@lastruleclass=\count128
+\@thisrulewidth=\dimen156
+) (/usr/share/texlive/texmf-dist/tex/latex/footnotehyper/footnotehyper.sty
+Package: footnotehyper 2018/01/23 v1.1 hyperref aware footnote.sty (JFB)
+\FNH@notes=\box59
+\FNH@width=\dimen157
+) (/usr/share/texlive/texmf-dist/tex/latex/caption/caption.sty
+Package: caption 2018/10/06 v3.3-154 Customizing captions (AR)
+(/usr/share/texlive/texmf-dist/tex/latex/caption/caption3.sty
+Package: caption3 2018/09/12 v1.8c caption3 kernel (AR)
+Package caption3 Info: TeX engine: e-TeX on input line 64.
+\captionmargin=\dimen158
+\captionmargin@=\dimen159
+\captionwidth=\dimen160
+\caption@tempdima=\dimen161
+\caption@indent=\dimen162
+\caption@parindent=\dimen163
+\caption@hangindent=\dimen164
+Package caption Info: Unknown document class (or package),
+(caption)             standard defaults will be used.
 )
 
-! Package fontspec Error: The font "Source Code Pro" cannot be found.
+Package caption Warning: Unsupported document class (or package) detected,
+(caption)                usage of the caption package is not recommended.
+See the caption package documentation for explanation.
 
-For immediate help type H <return>.
- ...                                              
-                                                  
-l.17 \fi
-         
+Package caption Info: \@makecaption = \long macro:#1#2->\vskip \abovecaptionski
+p \sbox \@tempboxa {#1: #2}\ifdim \wd \@tempboxa >\hsize {\FigCapFont #1} #2\pa
+r \else \global \@minipagefalse {\FigCapFont #1} #2\par \fi \vskip \belowcaptio
+nskip .
+\c@caption@flags=\count129
+\c@ContinuedFloat=\count130
+Package caption Info: hyperref package is loaded.
+Package caption Info: longtable package is loaded.
+(/usr/share/texlive/texmf-dist/tex/latex/caption/ltcaption.sty
+Package: ltcaption 2018/08/26 v1.4-95 longtable captions (AR)
+))
+! Undefined control sequence.
+l.107 \setmainfont
+                  [UprightFeatures={SmallCapsFont=AlegreyaSC-Regular}]{Alegr...
+ 
 Here is how much of TeX's memory you used:
- 14402 strings out of 427669
- 304767 string characters out of 3144952
- 391941 words of memory out of 3000000
- 18457 multiletter control sequences out of 15000+200000
- 532362 words of font info for 27 fonts, out of 3000000 for 9000
- 1348 hyphenation exceptions out of 8191
- 47i,0n,44p,813b,429s stack positions out of 5000i,500n,10000p,200000b,50000s
-
-No pages of output.
-
-
-! Sorry, but miktex-makemf did not succeed.
-
-! The log file hopefully contains the information to get MiKTeX going again:
-
-!   C:\Users\elise\AppData\Local\MiKTeX\2.9\miktex\log\miktex-makemf.log
-! Couldn't open `Source Code P.cfg'
-
-! hbf2gf (CJK ver. 4.8.4)
-
-
-! Sorry, but miktex-maketfm did not succeed.
-
-! The log file hopefully contains the information to get MiKTeX going again:
-
-!   C:\Users\elise\AppData\Local\MiKTeX\2.9\miktex\log\miktex-maketfm.log
+ 13515 strings out of 492615
+ 196175 string characters out of 6131390
+ 336856 words of memory out of 5000000
+ 17324 multiletter control sequences out of 15000+600000
+ 4702 words of font info for 16 fonts, out of 8000000 for 9000
+ 1141 hyphenation exceptions out of 8191
+ 36i,0n,38p,813b,271s stack positions out of 5000i,500n,10000p,200000b,80000s
+!  ==> Fatal error occurred, no output PDF file produced!

--- a/Cours_SpatialR.tex
+++ b/Cours_SpatialR.tex
@@ -1,40 +1,52 @@
-\documentclass[12pt,]{krantz}
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+\PassOptionsToPackage{dvipsnames,svgnames*,x11names*}{xcolor}
+%
+\documentclass[
+  12pt,
+]{krantz}
 \usepackage{lmodern}
 \usepackage{amssymb,amsmath}
 \usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
 \ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
   \usepackage[T1]{fontenc}
   \usepackage[utf8]{inputenc}
-\else % if luatex or xelatex
-  \ifxetex
-    \usepackage{mathspec}
-  \else
-    \usepackage{fontspec}
-  \fi
-  \defaultfontfeatures{Ligatures=TeX,Scale=MatchLowercase}
-    \setmonofont[Mapping=tex-ansi,Scale=0.7]{Source Code Pro}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+  \usepackage{unicode-math}
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+  \setmonofont[Scale=0.7]{Source Code Pro}
 \fi
-% use upquote if available, for straight quotes in verbatim environments
+% Use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
-% use microtype if available
-\IfFileExists{microtype.sty}{%
-\usepackage[]{microtype}
-\UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
+\IfFileExists{microtype.sty}{% use microtype if available
+  \usepackage[]{microtype}
+  \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 }{}
-\PassOptionsToPackage{hyphens}{url} % url is loaded by hyperref
-\usepackage[unicode=true]{hyperref}
-\PassOptionsToPackage{usenames,dvipsnames}{color} % color is loaded by hyperref
+\makeatletter
+\@ifundefined{KOMAClassName}{% if non-KOMA class
+  \IfFileExists{parskip.sty}{%
+    \usepackage{parskip}
+  }{% else
+    \setlength{\parindent}{0pt}
+    \setlength{\parskip}{6pt plus 2pt minus 1pt}}
+}{% if KOMA class
+  \KOMAoptions{parskip=half}}
+\makeatother
+\usepackage{xcolor}
+\IfFileExists{xurl.sty}{\usepackage{xurl}}{} % add URL line breaks if available
+\IfFileExists{bookmark.sty}{\usepackage{bookmark}}{\usepackage{hyperref}}
 \hypersetup{
-            pdftitle={SCI 1031 Visualisation et analyse de données spatiales sous R},
-            colorlinks=true,
-            linkcolor=Maroon,
-            citecolor=Blue,
-            urlcolor=Blue,
-            breaklinks=true}
-\urlstyle{same}  % don't use monospace font for urls
-\usepackage{natbib}
-\bibliographystyle{apalike}
+  pdftitle={SCI 1031 Visualisation et analyse de données spatiales sous R},
+  colorlinks=true,
+  linkcolor=Maroon,
+  filecolor=Maroon,
+  citecolor=Blue,
+  urlcolor=Blue,
+  pdfcreator={LaTeX via pandoc}}
+\urlstyle{same} % disable monospaced font for URLs
 \usepackage{color}
 \usepackage{fancyvrb}
 \newcommand{\VerbBar}{|}
@@ -44,210 +56,2140 @@
 \usepackage{framed}
 \definecolor{shadecolor}{RGB}{248,248,248}
 \newenvironment{Shaded}{\begin{snugshade}}{\end{snugshade}}
-\newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
+\newcommand{\AlertTok}[1]{\textcolor[rgb]{0.94,0.16,0.16}{#1}}
+\newcommand{\AnnotationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.77,0.63,0.00}{#1}}
+\newcommand{\BaseNTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
+\newcommand{\BuiltInTok}[1]{#1}
+\newcommand{\CharTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\CommentTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
+\newcommand{\CommentVarTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\ConstantTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
 \newcommand{\DataTypeTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{#1}}
 \newcommand{\DecValTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
-\newcommand{\BaseNTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
-\newcommand{\FloatTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
-\newcommand{\ConstantTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
-\newcommand{\CharTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
-\newcommand{\SpecialCharTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
-\newcommand{\StringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
-\newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
-\newcommand{\SpecialStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
-\newcommand{\ImportTok}[1]{#1}
-\newcommand{\CommentTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
 \newcommand{\DocumentationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
-\newcommand{\AnnotationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
-\newcommand{\CommentVarTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
-\newcommand{\OtherTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{#1}}
-\newcommand{\FunctionTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
-\newcommand{\VariableTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
-\newcommand{\ControlFlowTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
-\newcommand{\OperatorTok}[1]{\textcolor[rgb]{0.81,0.36,0.00}{\textbf{#1}}}
-\newcommand{\BuiltInTok}[1]{#1}
-\newcommand{\ExtensionTok}[1]{#1}
-\newcommand{\PreprocessorTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
-\newcommand{\AttributeTok}[1]{\textcolor[rgb]{0.77,0.63,0.00}{#1}}
-\newcommand{\RegionMarkerTok}[1]{#1}
-\newcommand{\InformationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
-\newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
-\newcommand{\AlertTok}[1]{\textcolor[rgb]{0.94,0.16,0.16}{#1}}
 \newcommand{\ErrorTok}[1]{\textcolor[rgb]{0.64,0.00,0.00}{\textbf{#1}}}
+\newcommand{\ExtensionTok}[1]{#1}
+\newcommand{\FloatTok}[1]{\textcolor[rgb]{0.00,0.00,0.81}{#1}}
+\newcommand{\FunctionTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\ImportTok}[1]{#1}
+\newcommand{\InformationTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
+\newcommand{\KeywordTok}[1]{\textcolor[rgb]{0.13,0.29,0.53}{\textbf{#1}}}
 \newcommand{\NormalTok}[1]{#1}
+\newcommand{\OperatorTok}[1]{\textcolor[rgb]{0.81,0.36,0.00}{\textbf{#1}}}
+\newcommand{\OtherTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{#1}}
+\newcommand{\PreprocessorTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textit{#1}}}
+\newcommand{\RegionMarkerTok}[1]{#1}
+\newcommand{\SpecialCharTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\SpecialStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\StringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\VariableTok}[1]{\textcolor[rgb]{0.00,0.00,0.00}{#1}}
+\newcommand{\VerbatimStringTok}[1]{\textcolor[rgb]{0.31,0.60,0.02}{#1}}
+\newcommand{\WarningTok}[1]{\textcolor[rgb]{0.56,0.35,0.01}{\textbf{\textit{#1}}}}
 \usepackage{longtable,booktabs}
-% Fix footnotes in tables (requires footnote package)
-\IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{long table}}{}
-\usepackage{graphicx,grffile}
+% Correct order of tables after \paragraph or \subparagraph
+\usepackage{etoolbox}
 \makeatletter
-\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
-\def\maxheight{\ifdim\Gin@nat@height>\textheight\textheight\else\Gin@nat@height\fi}
+\patchcmd\longtable{\par}{\if@noskipsec\mbox{}\fi\par}{}{}
 \makeatother
-% Scale images if necessary, so that they will not overflow the page
-% margins by default, and it is still possible to overwrite the defaults
-% using explicit options in \includegraphics[width, height, ...]{}
-\setkeys{Gin}{width=\maxwidth,height=\maxheight,keepaspectratio}
-\IfFileExists{parskip.sty}{%
-\usepackage{parskip}
-}{% else
-\setlength{\parindent}{0pt}
-\setlength{\parskip}{6pt plus 2pt minus 1pt}
-}
-\setlength{\emergencystretch}{3em}  % prevent overfull lines
+% Allow footnotes in longtable head/foot
+\IfFileExists{footnotehyper.sty}{\usepackage{footnotehyper}}{\usepackage{footnote}}
+\makesavenoteenv{longtable}
+\setlength{\emergencystretch}{3em} % prevent overfull lines
 \providecommand{\tightlist}{%
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 \setcounter{secnumdepth}{5}
-% Redefines (sub)paragraphs to behave more like sections
-\ifx\paragraph\undefined\else
-\let\oldparagraph\paragraph
-\renewcommand{\paragraph}[1]{\oldparagraph{#1}\mbox{}}
-\fi
-\ifx\subparagraph\undefined\else
-\let\oldsubparagraph\subparagraph
-\renewcommand{\subparagraph}[1]{\oldsubparagraph{#1}\mbox{}}
+\usepackage{booktabs}
+\usepackage{longtable}
+\usepackage[bf,singlelinecheck=off]{caption}
+
+\setmainfont[UprightFeatures={SmallCapsFont=AlegreyaSC-Regular}]{Alegreya}
+
+\usepackage{framed,color}
+\definecolor{shadecolor}{RGB}{248,248,248}
+
+\renewcommand{\textfraction}{0.05}
+\renewcommand{\topfraction}{0.8}
+\renewcommand{\bottomfraction}{0.8}
+\renewcommand{\floatpagefraction}{0.75}
+
+\renewenvironment{quote}{\begin{VF}}{\end{VF}}
+\let\oldhref\href
+\renewcommand{\href}[2]{#2\footnote{\url{#1}}}
+
+\ifxetex
+  \usepackage{letltxmacro}
+  \setlength{\XeTeXLinkMargin}{1pt}
+  \LetLtxMacro\SavedIncludeGraphics\includegraphics
+  \def\includegraphics#1#{% #1 catches optional stuff (star/opt. arg.)
+    \IncludeGraphicsAux{#1}%
+  }%
+  \newcommand*{\IncludeGraphicsAux}[2]{%
+    \XeTeXLinkBox{%
+      \SavedIncludeGraphics#1{#2}%
+    }%
+  }%
 \fi
 
-% set default figure placement to htbp
 \makeatletter
-\def\fps@figure{htbp}
+\newenvironment{kframe}{%
+\medskip{}
+\setlength{\fboxsep}{.8em}
+ \def\at@end@of@kframe{}%
+ \ifinner\ifhmode%
+  \def\at@end@of@kframe{\end{minipage}}%
+  \begin{minipage}{\columnwidth}%
+ \fi\fi%
+ \def\FrameCommand##1{\hskip\@totalleftmargin \hskip-\fboxsep
+ \colorbox{shadecolor}{##1}\hskip-\fboxsep
+     % There is no \\@totalrightmargin, so:
+     \hskip-\linewidth \hskip-\@totalleftmargin \hskip\columnwidth}%
+ \MakeFramed {\advance\hsize-\width
+   \@totalleftmargin\z@ \linewidth\hsize
+   \@setminipage}}%
+ {\par\unskip\endMakeFramed%
+ \at@end@of@kframe}
 \makeatother
 
-\usepackage{booktabs}
+\makeatletter
+\@ifundefined{Shaded}{
+}{\renewenvironment{Shaded}{\begin{kframe}}{\end{kframe}}}
+\makeatother
+
+\newenvironment{rmdblock}[1]
+  {
+  \begin{itemize}
+  \renewcommand{\labelitemi}{
+    \raisebox{-.7\height}[0pt][0pt]{
+      {\setkeys{Gin}{width=3em,keepaspectratio}\includegraphics{images/#1}}
+    }
+  }
+  \setlength{\fboxsep}{1em}
+  \begin{kframe}
+  \item
+  }
+  {
+  \end{kframe}
+  \end{itemize}
+  }
+\newenvironment{rmdnote}
+  {\begin{rmdblock}{note}}
+  {\end{rmdblock}}
+\newenvironment{rmdcaution}
+  {\begin{rmdblock}{caution}}
+  {\end{rmdblock}}
+\newenvironment{rmdimportant}
+  {\begin{rmdblock}{important}}
+  {\end{rmdblock}}
+\newenvironment{rmdtip}
+  {\begin{rmdblock}{tip}}
+  {\end{rmdblock}}
+\newenvironment{rmdwarning}
+  {\begin{rmdblock}{warning}}
+  {\end{rmdblock}}
+
+\usepackage{makeidx}
+\makeindex
+
+\urlstyle{tt}
+
+\usepackage{amsthm}
+\makeatletter
+\def\thm@space@setup{%
+  \thm@preskip=8pt plus 2pt minus 4pt
+  \thm@postskip=\thm@preskip
+}
+\makeatother
+
+\frontmatter
+\usepackage[]{natbib}
+\bibliographystyle{apalike}
 
 \title{SCI 1031 Visualisation et analyse de données spatiales sous R}
 \author{}
-\date{\vspace{-2.5em}2020-01-10}
+\date{\vspace{-2.5em}2020-05-27}
 
 \begin{document}
 \maketitle
 
+%\cleardoublepage\newpage\thispagestyle{empty}\null
+%\cleardoublepage\newpage\thispagestyle{empty}\null
+%\cleardoublepage\newpage
+\thispagestyle{empty}
+\begin{center}
+\includegraphics{images/dedication.pdf}
+\end{center}
+
+\setlength{\abovedisplayskip}{-5pt}
+\setlength{\abovedisplayshortskip}{-5pt}
+
 {
-\hypersetup{linkcolor=black}
-\setcounter{tocdepth}{2}
+\hypersetup{linkcolor=}
+\setcounter{tocdepth}{0}
 \tableofcontents
 }
 \listoftables
 \listoffigures
-\section*{}\label{section}
-\addcontentsline{toc}{section}{}
+\hypertarget{bienvenue}{%
+\chapter*{Bienvenue!}\label{bienvenue}}
 
-\part{À propos du cours}\label{part-uxe0-propos-du-cours}
 
-\section*{Présentation}\label{pruxe9sentation}
-\addcontentsline{toc}{section}{Présentation}
+Bienvenue dans le cours SCI 1031 Visualisation et analyse de données spatiales avec R.
 
-Le cours SCI 1031 blabla
+LE COURS EST PRÉSENTEMENT EN CONSTUCTION: REVENEZ PLUS TARD!
 
-\section*{Feuille de route}\label{feuille-de-route}
-\addcontentsline{toc}{section}{Feuille de route}
+\mainmatter
+
+\hypertarget{part-uxe0-propos-du-cours}{%
+\part{À propos du cours}\label{part-uxe0-propos-du-cours}}
+
+\hypertarget{pruxe9sentation}{%
+\chapter*{Présentation}\label{pruxe9sentation}}
+
+
+Présentation générale du cours\\
+Je n'ai jamais utilisé R, puis-je suivre ce cours?
+
+\hypertarget{objectifs}{%
+\section*{Objectifs}\label{objectifs}}
+
+
+Les objectifs du cours sont:
+
+À la fin du cours vous saurez \ldots{}
+
+\hypertarget{fonctionnement-du-cours}{%
+\section*{Fonctionnement du cours}\label{fonctionnement-du-cours}}
+
+
+Le cours est divisé en X modules et s'échelonne sur 15 semaines.\\
+La feuille de route explique \ldots{}\\
+Elle se veut un guide, une suggestion, \ldots{}\\
+Guide des études à distance
+
+\hypertarget{ruxe9troaction}{%
+\section*{Rétroaction}\label{ruxe9troaction}}
+
+
+Mode de communication\\
+Temps de réponse aux questions, temps pour remise des notes\\
+Accusé de réception\\
+Réponses rapides\\
+Commentaires
+
+\hypertarget{travaux-notuxe9s}{%
+\section*{Travaux notés}\label{travaux-notuxe9s}}
+
+
+Il y a X travaux noté\\
+Les gabarits des travaux notés se trouvent ici X
+
+\hypertarget{sources-de-donnuxe9es}{%
+\section*{Sources de données}\label{sources-de-donnuxe9es}}
+
+
+Vous pouvez trouver toutes les sources de données utilisées dans ce cours ici X
+
+\hypertarget{utilisation-de-r}{%
+\section*{Utilisation de R}\label{utilisation-de-r}}
+
+
+Pourquoi utilisons-nous R dans ce cours?\\
+Si vous avez des questions, utilisez la rubrique Ressources
+
+\hypertarget{feuille-de-route}{%
+\chapter*{Feuille de route}\label{feuille-de-route}}
+
 
 Échéancier semaines vs modules
 
-\section*{Ressources}\label{ressources}
-\addcontentsline{toc}{section}{Ressources}
+\hypertarget{ressources-r}{%
+\chapter*{Ressources R}\label{ressources-r}}
 
-\subsection*{Guide R}\label{guide-r}
-\addcontentsline{toc}{subsection}{Guide R}
 
-\subsection*{Guide shiny app}\label{guide-shiny-app}
-\addcontentsline{toc}{subsection}{Guide shiny app}
+\hypertarget{guide-guxe9nuxe9ral-r}{%
+\section*{Guide général R}\label{guide-guxe9nuxe9ral-r}}
 
-\section*{Crédits}\label{cruxe9dits}
-\addcontentsline{toc}{section}{Crédits}
+
+\hypertarget{les-libraries-r}{%
+\section*{Les libraries R}\label{les-libraries-r}}
+
+
+\hypertarget{guide-r-markdown}{%
+\section*{Guide R-Markdown}\label{guide-r-markdown}}
+
+
+\hypertarget{guide-shiny-app}{%
+\section*{Guide shiny app}\label{guide-shiny-app}}
+
+
+\hypertarget{ruxe9fuxe9rences-r}{%
+\section*{Références R}\label{ruxe9fuxe9rences-r}}
+
+
+\#\#\#Les couleurs dans R \{-\}
+
+\#\#\#Les thèmes d'une carte \{-\}
+
+\hypertarget{donnuxe9es}{%
+\chapter*{Données}\label{donnuxe9es}}
+
+
+Cette rubrique répertorie différentes bases de données spatiales.\\
+(!!) Vous êtes tombé sur une base de donnée intéressante qui ne figure pas plus bas? Partagez avec moi votre découverte et je l'ajouterai à cette liste.
+
+\hypertarget{donnuxe9es-utilisuxe9es-dans-le-cours}{%
+\section*{Données utilisées dans le cours}\label{donnuxe9es-utilisuxe9es-dans-le-cours}}
+
+
+\hypertarget{autres-sources-de-donnuxe9es}{%
+\section*{Autres sources de données}\label{autres-sources-de-donnuxe9es}}
+
+
+\hypertarget{travaux-notuxe9s-1}{%
+\chapter*{Travaux notés}\label{travaux-notuxe9s-1}}
+
+
+Le cours comprends 5 travaux notés et 1 examen à réaliser à la maison.\\
+La feuille de route vous fourni les moments auxquels les travaux doivent être entrepris et remis.
+
+\hypertarget{travail-notuxe9-1}{%
+\section*{Travail noté 1}\label{travail-notuxe9-1}}
+
+
+\hypertarget{travail-notuxe9-2}{%
+\section*{Travail noté 2}\label{travail-notuxe9-2}}
+
+
+\hypertarget{travail-notuxe9-3}{%
+\section*{Travail noté 3}\label{travail-notuxe9-3}}
+
+
+\hypertarget{travail-notuxe9-4}{%
+\section*{Travail noté 4}\label{travail-notuxe9-4}}
+
+
+\hypertarget{examen}{%
+\section*{Examen}\label{examen}}
+
+
+\hypertarget{cruxe9dits}{%
+\chapter*{Crédits}\label{cruxe9dits}}
+
 
 Conceptrice: Élise Filotas
 
-\part{Apprentissage}\label{part-apprentissage}
+\hypertarget{part-apprentissage}{%
+\part{Apprentissage}\label{part-apprentissage}}
 
-\section{Introduction}\label{intro}
+\hypertarget{intro}{%
+\chapter{Introduction}\label{intro}}
 
-You can label chapter and section titles using \texttt{\{\#label\}}
-after them, e.g., we can reference Chapter \ref{intro}. If you do not
-manually label them, there will be automatic labels anyway, e.g.,
-Chapter \ref{methods}.
+L'objectif principal de ce module est
 
-Figures and tables with captions will be placed in \texttt{figure} and
-\texttt{table} environments, respectively.
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+  abc
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on}{%
+\section{Leçon}\label{leuxe7on}}
+
+\hypertarget{les-donnuxe9es-spatiales}{%
+\subsection{Les données spatiales}\label{les-donnuxe9es-spatiales}}
+
+Les données spatiales d'hier à aujourd'hui
+
+\begin{itemize}
+\tightlist
+\item
+  La cartographie, la géomatique, la science des données
+\item
+  Exemples de données spatiales et d'applications
+\end{itemize}
+
+\hypertarget{les-outils}{%
+\subsection{Les outils}\label{les-outils}}
+
+Les outils et logiciels de visualisation et d'analyse géospatiale
+
+\begin{itemize}
+\tightlist
+\item
+  Logiciels commerciaux
+\item
+  Logiciels ouverts (open-source)
+\item
+  Services d'infonuagique
+\end{itemize}
+
+\hypertarget{lutilisation-de-r}{%
+\subsection{L'utilisation de R}\label{lutilisation-de-r}}
+
+L'utilisation de R pour l'analyse spatiale\ldots{}
+
+Les libraries essentielles:
+
+\begin{itemize}
+\tightlist
+\item
+  dplyr
+\item
+  ggplot2
+\item
+  raster
+\item
+  rgdal
+\item
+  rasterVis
+\item
+  remotes
+\item
+  sf
+\item
+  sp
+\item
+  GISTools
+\end{itemize}
+
+\hypertarget{exercice}{%
+\section{Exercice}\label{exercice}}
+
+\hypertarget{mon-premier-r-markdown}{%
+\subsection{Mon premier R-Markdown}\label{mon-premier-r-markdown}}
+
+\hypertarget{base}{%
+\chapter{La représentation spatiale}\label{base}}
+
+Ce module s'intéresse à la façon dont nous représentons les phénomènes spatiaux se déroulant à la surface de la Terre par des données spatiales. Les objectifs principaux sont de connaître les propriétés des deux types de données spatiales, les données vectorielles et les données matricielles, et de savoir interpréter le système de coordonnées de référence de données spatiales.
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\tightlist
+\item
+  Définir les propriétés principales des données vectorielles.
+\item
+  Reconnaître des formats de fichier de données vectorielles.
+\item
+  Définir les propriétés principales des données matricielles.
+\item
+  Reconnaître des formats de fichier de données matricielles.
+\item
+  Expliquer ce qu'est un référentiel géographique.
+\end{itemize}
+
+Dans la section Exercice, vous réaliserez une auto-évaluation pour vérifier votre acquisition des connaissances enseignées dans ce module.
+
+\hypertarget{leuxe7on-1}{%
+\section{Leçon}\label{leuxe7on-1}}
+
+\hypertarget{la-repruxe9sentation-de-donnuxe9es-spatiales}{%
+\subsection{La représentation de données spatiales}\label{la-repruxe9sentation-de-donnuxe9es-spatiales}}
+
+Les phénomènes spatiaux sont généralement perçus comme étant soit des entités discrètes avec des frontières bien définies ou encore comme des phénomènes continus qu'on observe de partout mais qui ne possèdent pas de frontières naturelles\footnote{Repris de l'introduction aux données spatiales du site \href{https://rspatial.org/raster/spatial/2-spatialdata.html}{Spatial Data Science}.}. Une rivière, une route, un pays, ou une ville sont tous des exemples d'entités spatiales discrètes (\ref{fig:vectomat}a). D'autre part, l'élévation, la température ou la qualité de l'air sont des exemples de phénomènes continus, appelés aussi des champs spatiaux (\ref{fig:vectomat}b).
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_vecto_vs_mat} \hfill{}
+
+\caption{Exemples de données vectorielles et matricielles : a) La carte délimitant les régions administratives du Québec est formée à partir de données vectorielles; b) La carte topographique du Québec (source : [https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/)](https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/))}\label{fig:vectomat}
+\end{figure}
+
+Les entités spatiales (ou objets) sont habituellement représentés par ce qu'on appelle des données vectorielles (« vector data », en anglais), alors que les phénomènes continues sont habituellement représentés par des données matricielles (« raster data », en anglais). Ces deux modèles sont des façons bien différentes de percevoir et de représenter les phénomènes spatiaux. Nous les décrivons dans les deux sous-sections suivantes.
+
+\hypertarget{les-donnuxe9es-vectorielles}{%
+\subsubsection{Les données vectorielles}\label{les-donnuxe9es-vectorielles}}
+
+\hypertarget{duxe9finition}{%
+\paragraph{Définition}\label{duxe9finition}}
+\addcontentsline{toc}{paragraph}{Définition}
+
+Les données vectorielles sont utilisées pour représenter des entités spatiales dont les frontières sont explicites et qui possède une localisation précise et unique. Les données vectorielles sont définies par leur localisation géographique, leur géométrie, et un ou plusieurs attributs.
+
+La \textbf{localisation géographique} désigne l'emplacement de l'entité selon un système de coordonnées géographiques ou un système de coordonnées projetées. Un système de coordonnées géographiques utilise un système en trois dimensions pour donner la position (x,y,z) ou longitude et latitude d'une entité spatiale sur la surface sphérique de la Terre. Un système de coordonnées projetées, donne la position d'une entité spatiale sur une surface plane à deux dimensions. Nous reviendrons sur les systèmes de coordonnées de référence à la section 2.1.3.
+
+La \textbf{géométrie} d'une entité spatiale correspond à sa forme (« shape », en anglais). Il existe trois principaux types de géométrie, aussi appelées des classes : les points, les lignes, et les polygones (Tableau \ref{fig:geometriesimple}). Ces classes peuvent être combinées pour créer des géométries plus complexes; des multipoints, des multilignes, des multipolygones, etc.
+
+\textbackslash begin\{figure\}
+
+\includegraphics[width=0.8\linewidth]{Module2/images/2_geometriesimple} \hfill{}
+
+\textbackslash caption\{Exemple de données vectorielles de géométrie simple. Remarquez que dans le cas d'un polygone, la première et la dernière coordonnées sont les mêmes. Tableau inspiré de Wikipedia (\url{https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry})\}\label{fig:geometriesimple}
+\textbackslash end\{figure\}
+
+Les données vectorielles comprennent également des variables additionnelles appelées des \textbf{attributs}. Les attributs sont toutes informations permettant de décrire une entité spatiale autres que sa localisation et sa géométrie.
+
+\hypertarget{guxe9omuxe9trie-et-topologie}{%
+\paragraph{Géométrie et topologie}\label{guxe9omuxe9trie-et-topologie}}
+\addcontentsline{toc}{paragraph}{Géométrie et topologie}
+
+Les \textbf{points} sont les données vectorielles les plus simples. Par exemple, un point pourrait représenter l'emplacement d'un restaurant dans une ville. Les attributs associés à ce point pourraient inclure les heures d'ouverture, sa spécialité culinaire, l'échelle de prix de son menu ou d'autres informations.
+
+\begin{figure}
+
+\includegraphics[width=0.6\linewidth]{Module2/images/2_multipoints} \hfill{}
+
+\caption{L’emplacement des stations de vélo en libre partage, *Bixi*, dans un quartier de Montréal correspond à une géométrie multipoints. Source : https://secure.bixi.com/map/}\label{fig:multipoints}
+\end{figure}
+
+Il est aussi possible de combiner plusieurs points ensemble dans une structure multipoints définie par un attribut unique (Figure \ref{fig:multipoints}). Par exemple, l'ensemble des restaurants de cuisine vietnamienne dans une ville pourrait être considéré comme une géométrie unique.
+
+La géométrie des \textbf{lignes} est plus complexe. Le terme ligne en analyse spatiale n'a pas la même définition que dans le langage usuel. Une ligne désigne un ensemble d'une seule ou de plusieurs polylignes (Figure \ref{fig:multilignes}). Une polyligne, quant à elle, désigne une séquence de segments de droite reliés entre eux. Ainsi, en analyse spatiale, une seule ligne pourrait représenter le fleuve Saint-Laurent et l'ensemble de ces affluents (rivière des Outaouais, rivière Saint-Maurice, le Fjord du Saguenay, etc.). D'autre part, il serait aussi possible de définir plusieurs lignes -- une pour chaque affluent, par exemple.
+
+\begin{figure}
+
+\includegraphics[width=0.6\linewidth]{Module2/images/2_multilignes} \hfill{}
+
+\caption{Le réseau hydrologique du bassin de l’Amazone représente un exemple d’un ensemble de polylignes. Source : Wang et al. 2020.}\label{fig:multilignes}
+\end{figure}
+
+Une ligne est représentée par un ensemble ordonné de coordonnées. Les segments de droite peuvent être calculés ou dessinés sur une carte en connectant ensemble les points. Ainsi, la représentation d'une ligne est semblable à celle d'une structure multipoints. La différence notable est que l'ordre des points est important dans la représentation d'une ligne car il est nécessaire de savoir quels points sont connectés entre eux.
+
+Un réseau -- par exemple un réseau routier ou un réseau hydrographique -- est une ligne de géométrie particulière comprenant des informations additionnelles comme le débit, la connectivité ou la distance.
+
+Un \textbf{polygone} désigne un ensemble de polylignes fermées. La géométrie d'un polygone est très semblable à celle des lignes à l'exception que la dernière paire de coordonnées doit coïncider avec la première paire afin de « fermer » le polygone.
+
+Une particularité des polygones est qu'ils peuvent comprendre des trous. C'est-à-dire qu'un polygone peut être entièrement compris à l'intérieur d'un polygone de plus grande superficie. Ceci est le cas d'une île au sein d'un lac, par exemple. Le polygone formant un îlot permet d'éliminer une partie du polygone qui l'englobe. De plus, alors que l'auto-intersection est permise pour une ligne (c'est-à-dire qu'elle peut se croiser sur elle-même), cette propriété n'est pas valide pour un polygone.
+
+Finalement, plusieurs polygones peuvent être considérés comme formant une géométrie unique ((Figure \ref{fig:multipolygones})). Par exemple, l'Indonésie est constituée de plusieurs îles. Chaque île peut être représentée par son propre polygone, ou encore l'ensemble des îles peut être représenté par un seul polygone (ou multi-polygones) désignant le pays en entier.
+
+\begin{figure}
+
+\includegraphics[width=0.5\linewidth]{Module2/images/2_multipolygones} \hfill{}
+
+\caption{Les Antilles peuvent être représentées par plusieurs polygones distincts pour chaque île, ou par un seul multipolygone. Source : https://fr.wikipedia.org/wiki/Antilles}\label{fig:multipolygones}
+\end{figure}
+
+Le modèle vectoriel est très efficace pour représenter la \textbf{topologie}. La topologie est une description des relations spatiales qu'ont les entités spatiales entre elles. Par exemple, une analyse de données vectorielles permettra de déterminer précisément si une entité spatiale est adjacente à une autre, si elle y est incluse, ou si elle s'intersecte (Figure \ref{fig:relationsspatiales}).
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_relationsspatiales} \hfill{}
+
+\caption{Exemples de relations spatiales entre deux entités spatiales : a) adjacence, b) inclusion, et c) intersection.}\label{fig:relationsspatiales}
+\end{figure}
+
+\hypertarget{format-de-donnuxe9es-vectorielles}{%
+\paragraph{Format de données vectorielles}\label{format-de-donnuxe9es-vectorielles}}
+\addcontentsline{toc}{paragraph}{Format de données vectorielles}
+
+Les données vectorielles peuvent être stockées dans une grande variété de formats différents. Ces formats ont évolué et continuent d'évoluer en fonction des besoins et des avancées technologiques. Plusieurs formats ont été développés pour être utilisés avec des logiciels commerciaux mais peuvent être lus et parfois édités par d'autres logiciels.
+
+Peu importe leur format, les données vectorielles sont toujours organisées selon une \emph{base de données relationnelle}. Un identifiant désigne chaque objet spatial et l'associe à une géométrie et à un ou plusieurs attributs (Tableau \ref{fig:baserelationnelle}).
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_baserelationnelle} \hfill{}
+
+\caption{Exemple d’une base de données relationnelle pour la carte des régions administratives du Québec (Figure ref(fig:vectomat)a). Chaque objet vectoriel dans la carte correspond à une ligne dans la base de données où figurent les attributs qui lui sont associés}\label{fig:baserelationnelle}
+\end{figure}
+
+Voici une liste non-exhaustive de formats de données vectorielles.
+
+\begin{quote}
+SHAPEFILE (.SHP, .DBF, .PRJ, .SHX)
+\end{quote}
+
+Le \emph{shapefile} est un format propriétaire d'ESRI créé pour les logiciels ArcView et ArcGIS. En français, on le nomme aussi un fichier de forme. À ce jour, il est le format le plus couramment utilisé pour les données vectorielles. Il est devenu un standard tant pour les plateformes commerciales qu'opensource.
+
+Un \emph{shapefile} comprend entre quatre types de fichiers qui contiennent des informations différentes et toutes essentielles à sa représentation.
+
+\begin{itemize}
+\tightlist
+\item
+  .shp : contient les données spatiales
+\item
+  .dbf : contient les données d'attributs
+\item
+  .prj : contient l'information sur la projection des données
+\item
+  .shx : fichier d'index
+\end{itemize}
+
+Le fichier d'index sert à lier entre elles les informations contenues dans les autres fichiers. Il existe parfois d'autres types de fichier d'index (.sbx, .sbn). Pour visualiser un \emph{shapefile}, il est nécessaire d'avoir tous les fichiers associés (et pas seulement le fichier .shp). Le fichier .prj peut être absent. En son absence, le shapefile peut être lu mais les données ne seront pas projetées adéquatement. Nous reviendrons sur le concept de projection plus tard dans ce module.
+
+\begin{quote}
+GEODATABASE
+\end{quote}
+
+La géodatabase est le nouveau format propriétaire d'ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au \emph{shapefile}. Une géodatabase est une façon de rassembler et d'organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \ref{fig:geodatabase}).
+
+\begin{figure}
+
+\includegraphics[width=0.5\linewidth]{Module2/images/2_geodatabase} \hfill{}
+
+\caption{Illustration d’une géodatabase telle que représentée sur le site web d’ArcGIS. Image récupérée à : https://desktop.arcgis.com/fr/arcmap/10.3/manage-data/geodatabases/a-quick-tour-of-the-geodatabase.htm}\label{fig:geodatabase}
+\end{figure}
+
+Par exemple, un projet sur le réseau de transport d'électricité au Québec pourrait nécessiter l'utilisation de plusieurs \emph{shapefiles} (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s'avère beaucoup plus efficace d'avoir l'ensemble de ces données au sein d'une même base.
+
+De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
+
+Malheureusement, bien que les géodatabases peuvent être lues avec \texttt{R}, elles peuvent seulement être modifiées dans ArcGIS.
+
+\begin{quote}
+GEOGRAPHIC JAVASCRIPT OBJECT NOTATION (.GEOJSON, .JSON)
+\end{quote}
+
+Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d'autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l'ensemble de l'information.
+
+\begin{quote}
+GOOGLE KEYHOLE MARKUP LANGUAGE (.KML, .KMZ)
+\end{quote}
+
+Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d'un fichier KML (KML-Zipped).
+
+\begin{quote}
+COVERAGE
+\end{quote}
+
+COVERAGE est le format propriétaire d'ESRI, développé pour le logiciel ArcInfo, qui a précédé le format \emph{shapefile}. C'est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
+
+\begin{quote}
+ARCINFO INTERCHANGE FILE (.EOO)
+\end{quote}
+
+C'est le format utilisé pour importer ou exporter des données d'ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
+
+\begin{quote}
+MAPINFO INTERCHANGE FILE (.MID, .MIF)
+\end{quote}
+
+C'est le format propriétaire de MapInfo, le compétiteur d'Esri. Le format \emph{shapefile} a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
+
+\begin{quote}
+WEB MAP SERVICE (WMS)
+\end{quote}
+
+N'est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l'information spatiale car elle permet de s'assurer que les données diffusées sont toujours à jour. L'utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
+
+\hypertarget{les-donnuxe9es-matricielles}{%
+\subsubsection{Les données matricielles}\label{les-donnuxe9es-matricielles}}
+
+\hypertarget{duxe9finition-1}{%
+\paragraph{Définition}\label{duxe9finition-1}}
+\addcontentsline{toc}{paragraph}{Définition}
+
+Les données matricielles représentent la surface terrestre par une grille régulière, communément appelé un raster, formée de rectangles de même forme et de même dimension appelés cellules ou pixels (Figure \ref{fig:raster}). À chaque cellule de la matrice est associée une valeur numérique (ou une valeur manquante) associée à un attribut d'intérêt. On appelle couche (« layer » en anglais) l'information recueillie dans la matrice.
+
+La valeur d'une cellule peut être continue (p.~ex. l'élévation - voir Figure \ref{fig:vectomat}b) ou catégorique (p.~ex. le zonage attribué à différents secteurs d'une ville tel que résidentiel, commercial ou industriel). Normalement, la valeur d'une cellule représente la valeur moyenne (ou la valeur prédominante) pour la superficie qu'elle couvre. Cependant, les valeurs sont parfois estimées pour le centre de la cellule.
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_raster} \hfill{}
+
+\caption{Exemple de données matricielles associées à des classes de végétation obtenues à partir d’une image satellitaire. Figure inspirée de NEON neonscience.org/resources/series/introduction-working-raster-data-r}\label{fig:raster}
+\end{figure}
+
+On peut utiliser une base de données relationnelle pour lier la valeur d'un pixel à l'attribut qu'il décrit (Figure \ref{fig:rastertable}). Contrairement aux données vectorielles où les polygones peuvent être associés à plusieurs attributs, une couche de données matricielles peut représenter un seul attribut.
+
+\begin{figure}
+
+\includegraphics[width=0.8\linewidth]{Module2/images/2_raster_table} \hfill{}
+
+\caption{Exemple de table relationnelle pour les données vectorielles de la Figure ref(fig:raster). Une valeur numérique est associée à chaque couleur de l’image ainsi qu’à un attribut, ici le type de végétation}\label{fig:rastertable}
+\end{figure}
+
+Dans leur format le plus simple, les données matricielles prennent la forme d'une image digitale. Cependant, pour associer les données matricielles à une location particulière sur la surface de la Terre, des informations spatiales doivent être ajoutées. Ainsi, un fichier de données matricielles géospatiales débute toujours par une section, appelée le «header» en anglais, qui procure la localisation.
+
+La localisation pour des données matricielles est définie par \textbf{l'étendue spatiale} (« extent » en anglais) couverte par la matrice, la \textbf{dimension} des cellules, le \textbf{nombre de rangées et de colonnes} qui divisent la superficie (respectivement « rows » et « columns » en anglais), et le \textbf{système de coordonnées géographiques ou projetées}. La dimension des cellules correspond à la résolution spatiale et peut être calculée à partir de l'étendue et du nombre de rangées et de colonnes.
+
+\hypertarget{ruxe9solution-et-guxe9omuxe9trie}{%
+\paragraph{Résolution et géométrie}\label{ruxe9solution-et-guxe9omuxe9trie}}
+\addcontentsline{toc}{paragraph}{Résolution et géométrie}
+
+La \textbf{résolution} définie la précision avec laquelle nous pouvons discerner les objets dans l'espace. Une grande résolution correspond à une matrice de données dont les cellules ont une petite taille (Figure \ref{fig:resolution}). En conséquence, une telle matrice est plus lente à visualiser et à manipuler, et requière un fichier plus volumineux. En contrepartie, une couche de données matricielles de faible résolution possède des cellules de plus grande taille, se visualise et se manipule plus rapidement, et est contenue dans un fichier moins volumineux.
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_resolution} \hfill{}
+
+\caption{Exemple du concept de résolution: plus la résolution est grande, plus la taille des cellules est petite. Dans cette figure, la résolution diminue de droite à gauche, et la taille des cellules augmente. Source de données: https://mern.gouv.qc.ca/nos-publications/spatiocarte-quebec/}\label{fig:resolution}
+\end{figure}
+
+Contrairement aux données vectorielles, la géométrie des données matricielles n'est pas définie explicitement par un ensemble de coordonnées. La géométrie peut être déduite en observant les démarcations se produisant aux limites des ensembles de cellules de même valeur. Cependant ces démarcations ne correspondent pas nécessairement aux frontières des entités sur le terrain (Figure \ref{fig:boundary}).
+
+\begin{figure}
+
+\includegraphics[width=0.8\linewidth]{Module2/images/2_raster_boundary} \hfill{}
+
+\caption{La géométrie des objets spatiaux matriciels. Les frontières d’une entité spatiale définie avec des données matricielles (droite) ne correspondent pas nécessairement aux frontières réelles (gauche)}\label{fig:boundary}
+\end{figure}
+
+Ainsi, lorsque nous représentons des objets spatiaux aux frontières bien définies, l'utilisation de données vectorielles plutôt que matricielles s'avère plus précise et plus efficace.
+
+Par ailleurs, la représentation de phénomènes continus avec des données vectorielles, nécessiterait de définir un grand nombre de petit polygones et d'enregistrer les coordonnées de chacun d'eux. Dans la majorité des cas, une telle représentation augmenterait dramatiquement le temps de traitement des données.
+
+\hypertarget{donnuxe9es-matricielles-uxe0-bande-unique-et-multi-bandes}{%
+\paragraph{Données matricielles à bande unique et multi-bandes}\label{donnuxe9es-matricielles-uxe0-bande-unique-et-multi-bandes}}
+\addcontentsline{toc}{paragraph}{Données matricielles à bande unique et multi-bandes}
+
+Un \emph{raster} peut contenir une couche ou plusieurs couches de données. Par exemple, un fichier de données matricielles d'élévation comprendra une seule couche de données, soit l'élévation à chaque cellule. Par exemple la carte topographique du Québec (Figure \ref{fig:vectomat}b) est un exemple de raster à une seule couche.
+
+Un raster à une seule couche peut aussi représenter des images en noir et blanc en utilisant un codage binaire pour exprimer différentes teintes de gris. Un codage sur 1 bit exprimera 21 (2) teintes de gris {[}0,1{]}, un codage sur 4 bit exprimera 24 (16) teintes de gris {[}0,1,2,\ldots,15{]}, et un codage sur 16 bits exprimera 216 (65536) teintes de gris {[}0,1,2,\ldots, 65535{]} (Figure \ref{fig:binaire}).
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_binaire} \hfill{}
+
+\caption{Exemple de codage binaire pour les *raster* à une couche: Images en blanc et noir utilisant différentes teintes de gris : 2 teintes (gauche), 8 teintes (centre) et 256 teintes (droite).}\label{fig:binaire}
+\end{figure}
+
+D'autres rasters peuvent contenir plusieurs couches, appelées aussi des bandes (ou canaux). Par exemple, les images de couleurs contiennent souvent trois bandes: une bande de rouge, une bande de vert et une bande de bleu. C'est ce qu'on nomme le format RGB (pour « red », « green », et « blue »). Ces bandes font références à des sections du spectre électromagnétique captées lors de la prise de l'image (Figure \ref{fig:electro}).
+
+\begin{figure}
+
+\includegraphics[width=0.5\linewidth]{Module2/images/2_electromagnetic_spectrum} \hfill{}
+
+\caption{*Raster* multibande. Les bandes blues, vertes et rouges correspondent à des sections du spectre électromagnétique. Image récupérée à https://desktop.arcgis.com/en/arcmap/10.3/manage-data/raster-and-images/raster-bands.htm.}\label{fig:electro}
+\end{figure}
+
+En combinant ces bandes, on peut recréer l'image (Figure \ref{fig:3bands}). Attention : chaque bande doit posséder les mêmes informations spatiales pour être superposée aux autres.
+
+\begin{figure}
+
+\includegraphics[width=1\linewidth]{Module2/images/2_3bands} \hfill{}
+
+\caption{Image satellitaire de région de l’Estrie. Le raster multi-bande contient une bande de rouge, une bande de vert et une bande de bleu. L’image couleur s’obtient en combinant les trois bandes.  Source de données: https://mern.gouv.qc.ca/nos-publications/spatiocarte-quebec/}\label{fig:3bands}
+\end{figure}
+
+\hypertarget{format-des-donnuxe9es-matricielles}{%
+\paragraph{Format des données matricielles}\label{format-des-donnuxe9es-matricielles}}
+\addcontentsline{toc}{paragraph}{Format des données matricielles}
+
+Tout comme les données vectorielles, les données matricielles peuvent être stockées dans une grande variété de formats différents. Les images possèdent des structures matricielles, ainsi les formats bien connus pour la transmission d'images sur le Web, .jpg (Joint Photographic Experts Group), .gif (Graphics Interchange Format), et .png (Portable Network Graphics), sont des exemples de format de données matricielles.
+
+Voici une liste non-exhaustive de formats de données matricielles.
+
+\begin{quote}
+GRID (.GRD)
+\end{quote}
+
+GRID est le format propriétaire d'ESRI pour stocker des données matricielles.
+
+\begin{quote}
+TIFF AND GEOTIFF (.TIF)
+\end{quote}
+
+Le Tag Image File format (TIFF) est utilisé pour le stockage d'images numériques. Il a la particularité d'être comme un contenant dans lequel plusieurs informations additionnelles sur les données peuvent être stockées (par ex. les attributs, et autres métadonnées).
+Le format GeoTIFF est un fichier .tif standard dans lequel on intègre des informations additionnelles sur la localisation spatiale des données (p.~ex. la résolution, l'étendue ou le système de coordonnées géographiques).
+
+\begin{quote}
+COMMA SEPERATED VALUE FORTMAT (.CSV)
+\end{quote}
+
+Le format .csv contient du texte séparé par des virgules, et correspond à une façon simple et très répandue de représenter des données matricielles. Par exemple, un fichier .csv pourrait être constitué de trois colonnes : la première pour la coordonnée x de la cellule, la deuxième pour sa coordonnée y, et la troisième pour la valeur de l'attribut.
+
+Une autre façon d'utiliser le format .csv est d'y stocker la matrice de données sous forme d'un tableau de dimension égale à cette dernière. Chaque entrée du tableau donne la valeur d'attribut pour la cellule correspondante. Les informations sur la localisation spatiale doivent alors être fournies en en-tête du fichier.
+
+\begin{quote}
+BITMAP (.BMP)
+\end{quote}
+
+BITMAP est le format d'images utilisé dans les applications de Microsoft Windows.
+
+De plus, comme expliqué plus haut, la géodatabase et Web Map Service sont aussi utilisés pour les données matricielles.
+
+Peu importe le type de données spatiales et le format utilisé pour les stocker, les données spatiales sont souvent accompagnées de \textbf{métadonnées}. Les métadonnées sont les données sur les données. C'est-à-dire qu'elles viennent donner des informations supplémentaires pour faciliter la compréhension et l'utilisation des données spatiales (p.~ex. l'origine des données, l'auteur.e, les détails sur la structure, le lexique, les abréviations, la légende, etc.). Idéalement, tout ensemble de données devrait être accompagné de métadonnées.
+
+\hypertarget{les-systuxe8mes-de-coordonnuxe9es-de-ruxe9fuxe9rence}{%
+\subsection{Les systèmes de coordonnées de référence}\label{les-systuxe8mes-de-coordonnuxe9es-de-ruxe9fuxe9rence}}
+
+\begin{itemize}
+\tightlist
+\item
+  Coordonnées angulaires, projections, notations.
+\end{itemize}
+
+\hypertarget{exercice-1}{%
+\section{Exercice}\label{exercice-1}}
+
+\hypertarget{vec}{%
+\chapter{Les données vectorielles}\label{vec}}
+
+L'objectif principal de ce module est d'apprendre à lire, interpréter et visualiser des données vectorielles\footnote{L'ensemble du matériel disponible dans ce module est adapté du cours \emph{Introduction to Geospatial Raster and Vector Data with R} \citep{Data_Carpentry_IntroGeospatial} de l'organisme \href{https://datacarpentry.org/}{Data Carpentry}. Data Carpentry développe et offre des formations variées et spécialisées sur le traitement et l'analyse de données. Ses formations s'adressent surtout aux chercheuses et chercheurs scientifiques, mais peuvent être consultées par quiconque car leur matériel est libre d'accès. N'hésitez donc pas à y jeter un coup d'œil.}
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\tightlist
+\item
+  Lire un \emph{shapefile}, explorer ses métadonnées et interpréter sa géométrie.
+\item
+  Visualiser des données vectorielles de type point, ligne et polygone.
+\item
+  Visualiser des données vectorielles par attribut.
+\item
+  Visualiser plusieurs données vectorielles au sein d'une même figure.
+\item
+  Transformer le système de coordonnées de référence de données vectorielles.
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\tightlist
+\item
+  \texttt{sf}
+\item
+  \texttt{rgdal}
+\item
+  \texttt{dplyr}
+\item
+  \texttt{ggplot2}
+\item
+  \texttt{ggpubr}
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\tightlist
+\item
+  \texttt{st\_read()}, \texttt{st\_write()}
+\item
+  \texttt{st\_geometry\_type()}
+\item
+  \texttt{st\_crs()}
+\item
+  \texttt{st\_bbox()}
+\item
+  \texttt{geom\_sf}
+\item
+  \texttt{filter()}
+\item
+  \texttt{st\_transform()}
+\item
+  \texttt{ggarrange()}
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données vectorielles relatives au réseau de pistes cyclables de la ville de Montréal et aux accidents routiers impliquant des bicyclettes.
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-2}{%
+\section{Leçon}\label{leuxe7on-2}}
+
+Dans le cadre de cette leçon, nous allons explorer des données vectorielles relatives au réseau de pistes cyclables de la ville de Montréal et aux accidents routiers impliquant des bicyclettes.
+Téléchargez les \href{https://github.com/elisefilotas/Donnees_spatiales/blob/master/Montreal_Velo.zip}{données sur le réseau de pistes cyclables}. Sauvegardez le dossier compressé (\texttt{zip}) dans votre répertoire de travail \texttt{Donnees} pour ce module, et dézippez-le. Le dossier Montreal\_Velo comprend trois sous-dossiers:
+
+\begin{itemize}
+\tightlist
+\item
+  \texttt{accidents}
+\item
+  \texttt{pistes}
+\item
+  \texttt{terre}.
+\end{itemize}
+
+\hypertarget{introduction-aux-donnuxe9es-vectorielles-sous-r}{%
+\subsection{Introduction aux données vectorielles sous R}\label{introduction-aux-donnuxe9es-vectorielles-sous-r}}
+
+\hypertarget{lire-un-shapefile-et-interpruxe9ter-sa-guxe9omuxe9trie}{%
+\subsubsection*{\texorpdfstring{Lire un \emph{shapefile} et interpréter sa géométrie}{Lire un shapefile et interpréter sa géométrie}}\label{lire-un-shapefile-et-interpruxe9ter-sa-guxe9omuxe9trie}}
+
+
+Pour lire des données vectorielles contenues dans un fichier \emph{shapefile}, nous allons utiliser la librairie \texttt{sf}. Notez que la librairie \texttt{rgdal} se charge automatiquement lorsque \texttt{sf} se charge.
 
 \begin{Shaded}
 \begin{Highlighting}[]
-\KeywordTok{par}\NormalTok{(}\DataTypeTok{mar =} \KeywordTok{c}\NormalTok{(}\DecValTok{4}\NormalTok{, }\DecValTok{4}\NormalTok{, .}\DecValTok{1}\NormalTok{, .}\DecValTok{1}\NormalTok{))}
-\KeywordTok{plot}\NormalTok{(pressure, }\DataTypeTok{type =} \StringTok{'b'}\NormalTok{, }\DataTypeTok{pch =} \DecValTok{19}\NormalTok{)}
+\KeywordTok{library}\NormalTok{(sf)}
+\end{Highlighting}
+\end{Shaded}
+
+Nous allons lire les trois \emph{shapefiles} suivants :
+
+\begin{itemize}
+\tightlist
+\item
+  Des données vectorielles de type polygone représentant la frontière de notre zone d'étude, ici, l'île de Montréal.
+\item
+  Des données vectorielles de type ligne représentant les pistes cyclables sur l'île de Montréal, et
+\item
+  Des données vectorielles de type point représentant la position d'accidents impliquant des bicyclettes.
+\end{itemize}
+
+Dans un premier temps, nous allons ouvrir les données vectorielles de type polygone qui contiennent les limites terrestres de l'île de Montréal. Pour lire ces données nous utiliserons la fonction \texttt{st\_read()} de la librarie \texttt{sf}. Pour utiliser \texttt{st\_read()} nous devons spécifier le chemin menant au fichier \emph{shapefile} à lire.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{chemin<-}\StringTok{"D:/votrechemin/SCI1031/Module3/Donnees/"}
+\NormalTok{nom_du_fichier <-}\StringTok{ }\KeywordTok{paste}\NormalTok{(chemin, }\StringTok{"/Montreal_Velo/terre/terre_shp.shp"}\NormalTok{, }\DataTypeTok{sep =} \StringTok{""}\NormalTok{)}
+\NormalTok{limites_terrestres <-}\StringTok{ }\KeywordTok{st_read}\NormalTok{(nom_du_fichier)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Reading layer `terre_shp' from data source `/home/kevcaz/Github/Books/sci1031/Module3/data/Montreal_Velo/terre/terre_shp.shp' using driver `ESRI Shapefile'
+Simple feature collection with 72 features and 1 field
+geometry type:  POLYGON
+dimension:      XY
+bbox:           xmin: 267500 ymin: 5029000 xmax: 306700 ymax: 5063000
+CRS:            32188
+\end{verbatim}
+
+La fonction \texttt{st\_read()} vous permet d'ores et déjà d'obtenir certaines informations sur la structure des données vectorielles que vous venez de lire: le type de géométrie (\texttt{geometry\ type}), la dimension des données (\texttt{dimension}), l'étendue spatiale des données (\texttt{bbox}), et les informations relatives au système de coordonnées de référence, le SPSG (\texttt{epsg\ (SRID)}) et la projection (\texttt{proj4string}). Nous explorerons ces propriétés en détails plus bas.
+
+Nous allons maintenant lire les données vectorielles de type ligne, en utilisant encore la fonction \texttt{st\_read()}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{chemin <-}\StringTok{"D:/votrechemin/SCI1031/Module3/Donnees/"}
+\NormalTok{nom_du_fichier<-}\StringTok{ }\KeywordTok{paste}\NormalTok{(chemin, }\StringTok{"/Montreal_Velo/pistes/pistes_cyclables_type.shp"}\NormalTok{, }\DataTypeTok{sep =} \StringTok{""}\NormalTok{)}
+\NormalTok{pistes_cyclables <-}\StringTok{ }\KeywordTok{st_read}\NormalTok{(nom_du_fichier)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Reading layer `pistes_cyclables_type' from data source `/home/kevcaz/Github/Books/sci1031/Module3/data/Montreal_Velo/pistes/pistes_cyclables_type.shp' using driver `ESRI Shapefile'
+Simple feature collection with 6395 features and 1 field
+geometry type:  MULTILINESTRING
+dimension:      XY
+bbox:           xmin: 268000 ymin: 5029000 xmax: 306300 ymax: 5063000
+CRS:            32188
+\end{verbatim}
+
+Finalement, nous allons lire les données vectorielles de type point, en utilisant toujours la fonction \texttt{st\_read()}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{chemin<-}\StringTok{"D:/votrechemin/SCI1031/Module3/Donnees/"}
+\NormalTok{nom_du_fichier<-}\StringTok{ }\KeywordTok{paste}\NormalTok{(chemin, }\StringTok{"/Montreal_Velo/accidents/accidents2018_Mtl_velo.shp"}\NormalTok{, }\DataTypeTok{sep =} \StringTok{""}\NormalTok{)}
+\NormalTok{pistes_cyclables <-}\StringTok{ }\KeywordTok{st_read}\NormalTok{(nom_du_fichier)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{accidents_velo <-}\StringTok{ }\KeywordTok{st_read}\NormalTok{(}\StringTok{"Module3/data/Montreal_Velo/accidents/accidents2018_Mtl_velo.shp"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Reading layer `accidents2018_Mtl_velo' from data source `/home/kevcaz/Github/Books/sci1031/Module3/data/Montreal_Velo/accidents/accidents2018_Mtl_velo.shp' using driver `ESRI Shapefile'
+Simple feature collection with 796 features and 1 field
+geometry type:  POINT
+dimension:      XY
+bbox:           xmin: 269500 ymin: 5030000 xmax: 305400 ymax: 5059000
+CRS:            32188
+\end{verbatim}
+
+Remarquez que le type de géométrie (\texttt{geometry\ type}) diffère pour les trois classes de données lues comme nous nous y attendions.
+
+\#\#\#\#Explorer les métadonnées d'un \emph{shapefile} \{-\}
+
+Les informations contenues dans un \emph{shapefile} sont appelées des métadonnées. Nous sommes particulièrement intéressées aux métadonnées géospatiales.
+
+Les métadonnées fondamentales d'un \emph{shapefile} sont :
+
+\begin{enumerate}
+\def\labelenumi{\arabic{enumi}.}
+\tightlist
+\item
+  Le type de géométrie : le type de classes des données vectorielles téléchargées.
+\item
+  La projection : le système de coordonnées de référence utilisé pour représenter les données.
+\item
+  L'étendue spatiale : la superficie géographique couvrant les données vectorielles.
+\end{enumerate}
+
+Nous pouvons explorer chacune de ces métadonnées en utilisant des fonctions de la librairie \texttt{sf}. Le type de géométrie est obtenu par la fonction \texttt{st\_geometry\_type()}. Par exemple, pour les limites terrestres de la ville de Montréal, cette fonction nous donne:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_geometry_type}\NormalTok{(limites_terrestres)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+ [1] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+ [7] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[13] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[19] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[25] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[31] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[37] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[43] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[49] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[55] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[61] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+[67] POLYGON POLYGON POLYGON POLYGON POLYGON POLYGON
+18 Levels: GEOMETRY POINT LINESTRING ... TRIANGLE
+\end{verbatim}
+
+Nous avons ainsi la confirmation que ces données vectorielles correspondent à des polygones (plus exactement, 72 polygones). Les 18 niveaux donnés en dessous constituent une liste des classes possibles de géométrie.
+
+En comparaison, pour les données de type ligne et de type point nous obtenons plutôt :
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_geometry_type}\NormalTok{(pistes_cyclables)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+   [1] MULTILINESTRING MULTILINESTRING MULTILINESTRING
+   [4] MULTILINESTRING MULTILINESTRING MULTILINESTRING
+...
+ [ reached getOption("max.print") -- omitted 3995 entries ]
+18 Levels: GEOMETRY POINT LINESTRING ... TRIANGLE
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_geometry_type}\NormalTok{(accidents_velo)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+  [1] POINT POINT POINT POINT POINT POINT POINT POINT
+  [9] POINT POINT POINT POINT POINT POINT POINT POINT
+...
+[793] POINT POINT POINT POINT
+18 Levels: GEOMETRY POINT LINESTRING ... TRIANGLE
+\end{verbatim}
+
+Vous remarquez alors que les pistes cyclables sont composées de nombreuses multilignes. Une multiligne étant elle-même un ensemble de lignes.
+Quant aux accidents de vélo, ce sont des points qui désignent la position précise des accidents. On en compte 796 en 2018.
+
+Vérifions maintenant la projection des \emph{shapefiles} en utilisant la fonction \texttt{st\_crs()} de la librarie \texttt{sf}:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_crs}\NormalTok{(limites_terrestres)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Coordinate Reference System:
+  User input: 32188 
+  wkt:
+PROJCS["NAD83 / MTM zone 8",
+    GEOGCS["NAD83",
+        DATUM["North_American_Datum_1983",
+            SPHEROID["GRS 1980",6378137,298.257222101,
+                AUTHORITY["EPSG","7019"]],
+            TOWGS84[0,0,0,0,0,0,0],
+            AUTHORITY["EPSG","6269"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4269"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",-73.5],
+    PARAMETER["scale_factor",0.9999],
+    PARAMETER["false_easting",304800],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AXIS["E(X)",EAST],
+    AXIS["N(Y)",NORTH],
+    AUTHORITY["EPSG","32188"]]
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_crs}\NormalTok{(pistes_cyclables)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Coordinate Reference System:
+  User input: 32188 
+  wkt:
+PROJCS["NAD83 / MTM zone 8",
+    GEOGCS["NAD83",
+        DATUM["North_American_Datum_1983",
+            SPHEROID["GRS 1980",6378137,298.257222101,
+                AUTHORITY["EPSG","7019"]],
+            TOWGS84[0,0,0,0,0,0,0],
+            AUTHORITY["EPSG","6269"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4269"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",-73.5],
+    PARAMETER["scale_factor",0.9999],
+    PARAMETER["false_easting",304800],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AXIS["E(X)",EAST],
+    AXIS["N(Y)",NORTH],
+    AUTHORITY["EPSG","32188"]]
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_crs}\NormalTok{(accidents_velo)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Coordinate Reference System:
+  User input: 32188 
+  wkt:
+PROJCS["NAD83 / MTM zone 8",
+    GEOGCS["NAD83",
+        DATUM["North_American_Datum_1983",
+            SPHEROID["GRS 1980",6378137,298.257222101,
+                AUTHORITY["EPSG","7019"]],
+            TOWGS84[0,0,0,0,0,0,0],
+            AUTHORITY["EPSG","6269"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4269"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",-73.5],
+    PARAMETER["scale_factor",0.9999],
+    PARAMETER["false_easting",304800],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AXIS["E(X)",EAST],
+    AXIS["N(Y)",NORTH],
+    AUTHORITY["EPSG","32188"]]
+\end{verbatim}
+
+Les données de tous les \emph{shapefiles} sont dans la projection de Mercator transverse (\texttt{+proj=tmerc}) et utilisent le Système de référence géodésique nord-américan de 1983 (\texttt{+datum=NAD83}). Il n'y a pas de EPSG assigné à ces données. Connaitre le SCR est essentiel pour interpréter l'étendue spatiale des objets spatiaux puisque celui-ci précise, en quelque sorte, les unités de mesure.
+
+Pour connaître l'étendue spatiale des \emph{shapefiles}, nous utilisons la fonction \texttt{st\_bbox()} de la librairie \texttt{sf} :
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_bbox}\NormalTok{(limites_terrestres)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+   xmin    ymin    xmax    ymax 
+ 267517 5029232  306669 5062642 
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_bbox}\NormalTok{(pistes_cyclables)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+   xmin    ymin    xmax    ymax 
+ 267984 5029291  306349 5062582 
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_bbox}\NormalTok{(accidents_velo)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+   xmin    ymin    xmax    ymax 
+ 269489 5029752  305368 5059058 
+\end{verbatim}
+
+L'étendue spatiale d'un \emph{shapefile} ou d'un objet spatial dans \texttt{R} représente les limites géographiques des données, ou la localisation des données les plus au sud, nord, est et ouest.
+
+ICI BESOIN D'UNE FIGURE COMME CELLE DE NEON
+
+Finalement, nous pouvons visualiser toutes les métadonnées et les attributs d'un \emph{shapefile} simplement en écrivant son nom dans la console \texttt{R}:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{limites_terrestres}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Simple feature collection with 72 features and 1 field
+geometry type:  POLYGON
+dimension:      XY
+bbox:           xmin: 267500 ymin: 5029000 xmax: 306700 ymax: 5063000
+CRS:            32188
+First 10 features:
+   DefaultAtt                       geometry
+1        <NA> POLYGON ((299608 5038364, 2...
+2        <NA> POLYGON ((301350 5036978, 3...
+3        <NA> POLYGON ((300403 5038997, 3...
+4        <NA> POLYGON ((300744 5039496, 3...
+5        <NA> POLYGON ((302032 5043372, 3...
+6        <NA> POLYGON ((302299 5043145, 3...
+7        <NA> POLYGON ((302508 5040978, 3...
+8        <NA> POLYGON ((304719 5062024, 3...
+9        <NA> POLYGON ((304927 5062499, 3...
+10       <NA> POLYGON ((305396 5062622, 3...
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{pistes_cyclables}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Simple feature collection with 6395 features and 1 field
+geometry type:  MULTILINESTRING
+dimension:      XY
+bbox:           xmin: 268000 ymin: 5029000 xmax: 306300 ymax: 5063000
+CRS:            32188
+First 10 features:
+                       TYPE_VOIE
+1         Piste cyclable sur rue
+2  Piste cyclable en site propre
+3              Chaussée désignée
+4                 Bande cyclable
+5  Piste cyclable en site propre
+6  Piste cyclable en site propre
+7  Piste cyclable en site propre
+8              Chaussée désignée
+9  Piste cyclable en site propre
+10 Piste cyclable en site propre
+                         geometry
+1  MULTILINESTRING ((297752 50...
+2  MULTILINESTRING ((305050 50...
+3  MULTILINESTRING ((299076 50...
+4  MULTILINESTRING ((287779 50...
+5  MULTILINESTRING ((300752 50...
+6  MULTILINESTRING ((300953 50...
+7  MULTILINESTRING ((299010 50...
+8  MULTILINESTRING ((276415 50...
+9  MULTILINESTRING ((293077 50...
+10 MULTILINESTRING ((304787 50...
+\end{verbatim}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{accidents_velo}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Simple feature collection with 796 features and 1 field
+geometry type:  POINT
+dimension:      XY
+bbox:           xmin: 269500 ymin: 5030000 xmax: 305400 ymax: 5059000
+CRS:            32188
+First 10 features:
+   FID               geometry
+1    0 POINT (279673 5041015)
+2    1 POINT (277292 5039169)
+3    2 POINT (275581 5036314)
+4    3 POINT (274728 5035946)
+5    4 POINT (283935 5040875)
+6    5 POINT (280442 5039871)
+7    6 POINT (279626 5040700)
+8    7 POINT (277734 5038853)
+9    8 POINT (276487 5038090)
+10   9 POINT (278357 5040125)
+\end{verbatim}
+
+\hypertarget{visualisation-de-shapefiles-sous-r}{%
+\subsection{\texorpdfstring{Visualisation de \emph{shapefiles} sous R}{Visualisation de shapefiles sous R}}\label{visualisation-de-shapefiles-sous-r}}
+
+\hypertarget{visualiser-des-donnuxe9es-vectorielles}{%
+\subsubsection*{Visualiser des données vectorielles}\label{visualiser-des-donnuxe9es-vectorielles}}
+
+
+Vous allez maintenant apprendre à visualer des données \emph{shapefile} en utilisant la fonction \texttt{ggplot()} de la librairie \texttt{ggplot2}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{library}\NormalTok{(ggplot2)}
+\end{Highlighting}
+\end{Shaded}
+
+Dans un premier temps, visualisons les limites terrestres de l'île de Montréal (Fig \ref{fig:plot-terre}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{() }\OperatorTok{+}
+\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ limites_terrestres, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{) }\OperatorTok{+}
+\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Limites terrestres de l'île de Montréal"}\NormalTok{)}
 \end{Highlighting}
 \end{Shaded}
 
 \begin{figure}
 
-{\centering \includegraphics[width=0.8\linewidth]{Cours_SpatialR_files/figure-latex/nice-fig-1} 
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-terre-1} 
 
 }
 
-\caption{Here is a nice figure!}\label{fig:nice-fig}
+\caption{Limites terrestres de l'île de Montréal}\label{fig:plot-terre}
 \end{figure}
 
-Reference a figure by its code chunk label with the \texttt{fig:}
-prefix, e.g., see Figure \ref{fig:nice-fig}. Similarly, you can
-reference tables generated from \texttt{knitr::kable()}, e.g., see Table
-\ref{tab:nice-tab}.
+La fonction \texttt{geom\_sf()} permet de faire des représentations simples d'objets vectoriels de géométrie de type point, ligne et polygone.
+Cette fonction peut prendre plusieurs arguments\footnote{Pour plus d'information sur la fonction \texttt{geom\_sf}, consultez le chapitre \href{https://ggplot2.tidyverse.org/reference/ggsf.html}{Visualise sf objects} \citep{Wickham_ggplot2_2016}}. Les arguments utilisés ici sont:
+
+\begin{itemize}
+\tightlist
+\item
+  les données (\texttt{data})
+\item
+  la taille du trait avec laquelle on illustre l'objet (\texttt{size})
+\item
+  la couleur du trait, et la couleur de la surface délimitée par le trait (\texttt{color}).
+\end{itemize}
+
+La fonction ggtitle permet d'ajouter un titre à la figure générée.
+
+Remarquez que chaque fonction est écrite sur sa propre ligne, pour faciliter la lecture des lignes de commande, et que chaque fonction qui s'ajoute à \texttt{ggplot()} est précédée par le signe plus \texttt{+}.
+
+Dans un deuxième temps, visualisons les pistes cyclables (Fig \ref{fig:plot-velo}).
 
 \begin{Shaded}
 \begin{Highlighting}[]
-\NormalTok{knitr}\OperatorTok{::}\KeywordTok{kable}\NormalTok{(}
-  \KeywordTok{head}\NormalTok{(iris, }\DecValTok{20}\NormalTok{), }\DataTypeTok{caption =} \StringTok{'Here is a nice table!'}\NormalTok{,}
-  \DataTypeTok{booktabs =} \OtherTok{TRUE}
+\KeywordTok{ggplot}\NormalTok{() }\OperatorTok{+}
+\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ pistes_cyclables, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"darkgreen"}\NormalTok{) }\OperatorTok{+}
+\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Pistes cyclables sur l'île de Montréal"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-velo-1} 
+
+}
+
+\caption{Pistes cyclables sur l'île de Montréal}\label{fig:plot-velo}
+\end{figure}
+
+Pour visualiser des lignes, nous n'avons évidemment pas besoin de définir l'argument \texttt{fill} car nous visualisons des lignes plutôt qu'une surface. Vous remarquerez que les lignes, cette fois, sont vertes foncées (\texttt{darkgreen}).
+
+Il existe 657 couleurs prédéfinies dans \texttt{R}. Taper la commande \texttt{colors()} dans votre console \texttt{R} pour voir afficher le nom des couleurs. Celles-sont sont listées par ordre alphabétique sauf pour la première couleur, qui est le blanc (\texttt{white}). Ainsi, vous pouvez utiliser une couleur en assignant son nom ou son numéro. Pour produire la figure précédente, \texttt{color\ =\ "darkgreen"} aurait pu être remplacé par
+\texttt{color\ =\ colors(){[}81{]}}. Essayez pour voir.
+
+Les couleurs peuvent aussi être définies selon leur composition en rouge, vert et bleu sur un intervalle allant de 0 à 255 - ce qu'on nomme le vecteur RGB (red, green, blue). Par exemple, la couleur jaune est représentée par le vecteur RGB (255, 255, 0). La couleur verte foncée, utilisée précédemment, est, quant à elle, représentée par le vecteur RGB (0, 100, 0). Les couleurs peuvent aussi être exprimées selon le système de notation \href{https://fr.wikipedia.org/wiki/Syst\%C3\%A8me_hexad\%C3\%A9cimal}{hexadécimal}. La fonction \texttt{rgb} permet de traduire un vecteur de couleur RGB en notation hexadécimal. Ainsi, pour produire la figure précédente, nous aurions pu définir le vecteur \texttt{vert\_fonce\ =\ rgb(0,\ 100,\ 0,\ maxColorValue=255)}, et remplacer \texttt{color\ =\ "darkgreen"} par \texttt{color\ =\ vert\_fonce}. Essayez pour voir.
+
+Pour en apprendre davantage sur les couleurs dans \texttt{R}, vous êtes invité à consulter le site \href{https://github.com/EarlGlynn/colorchart/wiki/Color-Chart-in-R}{Earl Glynn} et à conserver dans vos notes son \href{Module3/3_TableauCouleurs.pdf}{tableau synthèse des couleurs} dans \texttt{R}.
+
+Finalement, visualisons les accidents de la route impliquant des bicyclettes (Fig \ref{fig:plot-accidents}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{() }\OperatorTok{+}
+\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ accidents_velo, }\DataTypeTok{pch =} \DecValTok{19}\NormalTok{, }\DataTypeTok{cex =} \FloatTok{1.25}\NormalTok{, }\DataTypeTok{color =} \StringTok{"red"}\NormalTok{) }\OperatorTok{+}
+\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Accidents de la route avec cyclistes sur l'île de Montréal"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-accidents-1} 
+
+}
+
+\caption{Accidents de la route avec cyclistes sur l'île de Montréal}\label{fig:plot-accidents}
+\end{figure}
+
+Le symbole utilisé pour illustrer la position des accidents est défini par l'argument \texttt{pch\ =\ 19}. Il existe 25 formats de points différents prédéfinis dans \texttt{R}. Les voici:
+
+\begin{figure}
+
+{\centering \includegraphics[width=0.5\linewidth]{Module3/3_symbolesR} 
+
+}
+
+\caption{Symboles disponibles}\label{fig:plot-symbols}
+\end{figure}
+
+L'argument \texttt{cex}, quant à lui, indique le facteur par lequel la taille du symbole sera augmentée ou réduite par rapport à 1, la valeur par défaut. Par exemple, `cex = 1.5' indique que le symbole sera 50\% plus grand, alors que 0.5 indique que le symbole sera 50\% plus petit.
+
+Ainsi, nous pouvons changer les valeurs de ces arguments et représenter les accidents de vélo par des triangles oranges (Fig \ref{fig:plot-accidents2}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{() }\OperatorTok{+}
+\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ accidents_velo, }\DataTypeTok{pch =} \DecValTok{24}\NormalTok{, }\DataTypeTok{cex =} \FloatTok{1.5}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"orange"}\NormalTok{) }\OperatorTok{+}
+\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Accidents de la route avec cyclistes sur l'île de Montréal"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-accidents2-1} 
+
+}
+
+\caption{Symbole et couleur différents pour illustrer les accidents de la route avec cyclistes sur l'île de Montréal}\label{fig:plot-accidents2}
+\end{figure}
+
+\hypertarget{visualiser-des-donnuxe9es-vectorielles-par-attribut}{%
+\subsubsection*{Visualiser des données vectorielles par attribut}\label{visualiser-des-donnuxe9es-vectorielles-par-attribut}}
+
+
+Lorsque nous avons affiché les métadonnées du \emph{shapefile} \texttt{pistes\_cyclables}, vous avez peut-être observé que ce dernier comprenait l'attribut \texttt{TYPE\_VOIE} qui caractérise le type de pistes cyclables de chaque multiligne. Affichons les métadonnées à nouveau:
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{pistes_cyclables}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Simple feature collection with 6395 features and 1 field
+geometry type:  MULTILINESTRING
+dimension:      XY
+bbox:           xmin: 268000 ymin: 5029000 xmax: 306300 ymax: 5063000
+CRS:            32188
+First 10 features:
+                       TYPE_VOIE
+1         Piste cyclable sur rue
+2  Piste cyclable en site propre
+3              Chaussée désignée
+4                 Bande cyclable
+5  Piste cyclable en site propre
+6  Piste cyclable en site propre
+7  Piste cyclable en site propre
+8              Chaussée désignée
+9  Piste cyclable en site propre
+10 Piste cyclable en site propre
+                         geometry
+1  MULTILINESTRING ((297752 50...
+2  MULTILINESTRING ((305050 50...
+3  MULTILINESTRING ((299076 50...
+4  MULTILINESTRING ((287779 50...
+5  MULTILINESTRING ((300752 50...
+6  MULTILINESTRING ((300953 50...
+7  MULTILINESTRING ((299010 50...
+8  MULTILINESTRING ((276415 50...
+9  MULTILINESTRING ((293077 50...
+10 MULTILINESTRING ((304787 50...
+\end{verbatim}
+
+Utilisons la fonction \texttt{levels} pour connaître ces types de voie cyclables. La fonction \texttt{levels} donne les différentes valeurs que peuvent prendre un attribut.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{levels}\NormalTok{(pistes_cyclables}\OperatorTok{$}\NormalTok{TYPE_VOIE)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+[1] "Bande cyclable"                      
+[2] "Chaussée désignée"                   
+[3] "Piste cyclable au niveau du trottoir"
+[4] "Piste cyclable en site propre"       
+[5] "Piste cyclable sur rue"              
+[6] "Sentier polyvalent"                  
+\end{verbatim}
+
+Si vous ne connaissez pas la distinction entre ces types d'aménagement cyclable, consulter ce \href{Module3/3_Amenagement3Cyclable3Mtl.pdf}{document sommaire} de la \emph{Ville de Montréal}\footnote{Ville de Montréal. Aménagements cyclables. Repéré le 19 mars 2020}
+
+Nous voulons maintenant représenter les données vectorielles associées aux pistes cyclables de type \texttt{"Bande\ cyclable"}. Pour représenter une valeur précise d'un attribut, nous utiliserons la fonction \texttt{filter} de la librarie \texttt{dplyr}. Commençons par charger cette librairie.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{library}\NormalTok{(dplyr)}
+\end{Highlighting}
+\end{Shaded}
+
+Utilisons la fonction \texttt{filter} qui permet de filtrer l'ensemble des valeurs de l'attribut \texttt{TYPE\_VOIE}, pour ne retenir que les données dont la valeur est identique (ce qui s'exprime par l'opération \texttt{==}) à `\,``Bande cyclable''\,'. Nous nommerons ce sous-ensemble de données \texttt{Bande}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{Bande <-pistes_cyclables }\OperatorTok{%>%}
+\StringTok{  }\KeywordTok{filter}\NormalTok{(TYPE_VOIE }\OperatorTok{==}\StringTok{"Bande cyclable"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+Nous représentons ce sous-ensemble de données de la même manière que pour l'ensemble complet (Fig \ref{fig:plot-velo}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ Bande,  }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"darkgreen"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Pistes cyclables sur l'île de Montréal"}\NormalTok{, }\DataTypeTok{subtitle =} \StringTok{"Bande cyclable"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-voie3-1} 
+
+}
+
+\caption{Bandes cyclables sur l'île de Montréal}\label{fig:plot-voie3}
+\end{figure}
+
+Nous voulons maintenant représenter les six types de voie cyclable par six couleurs différentes. Créons d'abord un vecteur de six couleurs, ce qu'on appelle une palette de couleurs.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{couleurs_voie<-}\KeywordTok{c}\NormalTok{(}\StringTok{"darkgreen"}\NormalTok{, }\StringTok{"turquoise"}\NormalTok{, }\StringTok{"yellow"}\NormalTok{,}\StringTok{"darkblue"}\NormalTok{,}\StringTok{"violet"}\NormalTok{,}\StringTok{"orange"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+Nous pouvons demander à \texttt{ggplot} d'utiliser ces couleurs pour illustrer les différents types de voie cyclable (Fig \ref{fig:plot-voie5}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ pistes_cyclables,  }\KeywordTok{aes}\NormalTok{(}\DataTypeTok{color =}\NormalTok{ TYPE_VOIE))}\OperatorTok{+}
+\StringTok{  }\KeywordTok{scale_color_manual}\NormalTok{(}\DataTypeTok{values =}\NormalTok{ couleurs_voie)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{labs}\NormalTok{(}\DataTypeTok{color =} \StringTok{'Types de voie'}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Pistes cyclables sur l'île de Montréal"}\NormalTok{, }\DataTypeTok{subtitle =} \StringTok{"Types de voie"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-voie5-1} 
+
+}
+
+\caption{Types de voie cyclable sur l'île de Montréal}\label{fig:plot-voie5}
+\end{figure}
+
+La fonction \texttt{aes} décrit quelles variables dans les données (\texttt{data}) sont illustrées (dans notre exemple, ce sont \texttt{TYPE\_VOIE}) et par quelles
+caractéristiques visuelles\footnote{Pour plus d'information sur la fonction \texttt{aes}, consultez le chapitre \href{https://ggplot2.tidyverse.org/reference/aes.html}{Construct aesthetic mappings} \citep{Wickham_ggplot2_2016}}. On nomme ces caractéristiques visuelles les ``esthétiques'' (\texttt{aes} pour ``aesthetic'' en anglais). Dans le présent exemple, nous nous préoccupons seulement de la couleur des données vectorielles, mais nous aurions pu aussi changer leur taille, le type de lignes, ou la forme des symboles (si la géométrie des données étaient de type point).
+
+La fonction \texttt{scale\_color\_manual} permet de spécifier nos propres couleurs, sans quoi ce seront les couleurs par défaut qui seront utilisées\footnote{Pour plus d'information sur la fonction \texttt{scale\_colour\_manual}, consultez le chapitre \href{https://ggplot2.tidyverse.org/reference/scale_manual.html}{Create your own discrete scale} \citep{Wickham_ggplot2_2016}}.
+
+Finalement, la fonction \texttt{labs} permet d'assigner un titre à la légende, sans quoi c'est le nom de la variable, telle que nous l'avons définie dans \texttt{R} qui sera affichée, ici, \texttt{TYPE\_VOIE}.
+
+Nous pouvons aussi demander à \texttt{ggplot} de représenter les types de voie cyclable en utilisant différentes tailles de trait. De la même façon que précédemment, nous créons un vecteur de six tailles.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{tailles_voie<-}\KeywordTok{c}\NormalTok{(}\DecValTok{1}\NormalTok{,}\FloatTok{1.2}\NormalTok{,}\FloatTok{1.5}\NormalTok{,}\FloatTok{1.7}\NormalTok{,}\DecValTok{2}\NormalTok{,}\FloatTok{2.2}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+Puis représentatons les types de voie cyclable (Fig \ref{fig:plot-voie7}).
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ pistes_cyclables,  }\KeywordTok{aes}\NormalTok{(}\DataTypeTok{color =}\NormalTok{ TYPE_VOIE, }\DataTypeTok{size =}\NormalTok{ TYPE_VOIE))}\OperatorTok{+}
+\StringTok{  }\KeywordTok{scale_color_manual}\NormalTok{(}\DataTypeTok{values =}\NormalTok{ couleurs_voie)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{labs}\NormalTok{(}\DataTypeTok{color =} \StringTok{'Types de voie'}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{scale_size_manual}\NormalTok{(}\DataTypeTok{values =}\NormalTok{ tailles_voie)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{labs}\NormalTok{(}\DataTypeTok{size =} \StringTok{'Types de voie'}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Pistes cyclables sur l'île de Montréal"}\NormalTok{, }\DataTypeTok{subtitle =} \StringTok{"Types de voie"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{theme}\NormalTok{(}\DataTypeTok{legend.position =} \StringTok{"bottom"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-voie7-1} 
+
+}
+
+\caption{Types de voie cyclable sur l'île de Montréal (couleur et taille des traits)}\label{fig:plot-voie7}
+\end{figure}
+
+La légende tient compte à la fois de la couleur, et de la taille des traits. De plus, nous l'avons affichée au bas de la figure.
+
+\hypertarget{visualiser-plusieurs-shapefiles}{%
+\subsubsection*{\texorpdfstring{Visualiser plusieurs \emph{shapefiles}}{Visualiser plusieurs shapefiles}}\label{visualiser-plusieurs-shapefiles}}
+
+
+Nous allons maintenant représenter les données vectorielles \texttt{limites\ terrestres}, \texttt{pistes\_cyclables} et \texttt{accidents\_velo} au sein d'une même figure. Il s'agit d'utiliser la fonction \texttt{geom\_sf} pour chaque couche de données et de les combiner en utilisant le \texttt{+}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ limites_terrestres, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ pistes_cyclables, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"darkgreen"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ accidents_velo, }\DataTypeTok{pch =} \DecValTok{19}\NormalTok{, }\DataTypeTok{cex =} \FloatTok{1.25}\NormalTok{, }\DataTypeTok{color =} \StringTok{"red"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Pistes cyclables sur l'île de Montréal et Accidents routiers impliquant des vélos"}\NormalTok{)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-all1-1} 
+
+}
+
+\caption{Pistes cyclables et position des accidents routiers impliquant des bicyclettes sur l'île de Montréal}\label{fig:plot-all1}
+\end{figure}
+
+Nous pouvons créer une carte plus précise qui spécifie les types de voie cyclable et ajouter une légende.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ limites_terrestres, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ pistes_cyclables, }\DataTypeTok{size =} \FloatTok{1.5}\NormalTok{, }\KeywordTok{aes}\NormalTok{(}\DataTypeTok{color =}\NormalTok{ TYPE_VOIE),  }\DataTypeTok{show.legend =} \StringTok{"line"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{scale_color_manual}\NormalTok{(}\DataTypeTok{values =}\NormalTok{ couleurs_voie,}\DataTypeTok{name =} \StringTok{"Types de voie"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ accidents_velo, }\DataTypeTok{pch =} \DecValTok{24}\NormalTok{, }\DataTypeTok{cex =} \DecValTok{2}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"red"}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{)}\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Types de voie cyclable et Accidents routiers impliquant des vélos"}\NormalTok{)}\OperatorTok{+}
+\KeywordTok{theme}\NormalTok{(}
+      \CommentTok{#Caractéristiques de la figure elle-même}
+      \DataTypeTok{panel.background =} \KeywordTok{element_rect}\NormalTok{(}\DataTypeTok{fill =} \StringTok{"black"}\NormalTok{), }\CommentTok{#le dessous de la carte}
+      \DataTypeTok{plot.background =} \KeywordTok{element_rect}\NormalTok{(}\DataTypeTok{fill =} \StringTok{"black"}\NormalTok{),  }\CommentTok{#le contour de la carte}
+      \DataTypeTok{panel.grid.major =} \KeywordTok{element_blank}\NormalTok{(),              }\CommentTok{#retirer la grille cartésienne}
+      \DataTypeTok{axis.ticks =} \KeywordTok{element_blank}\NormalTok{(),                    }\CommentTok{#retirer les traits sur les axes}
+      \DataTypeTok{axis.text.x =} \KeywordTok{element_blank}\NormalTok{(),                   }\CommentTok{#retirer les traits les noms ou les numéros de ces traits}
+      \DataTypeTok{axis.text.y =} \KeywordTok{element_blank}\NormalTok{(),}
+      \DataTypeTok{plot.title =} \KeywordTok{element_text}\NormalTok{(}\DataTypeTok{colour =} \StringTok{"white"}\NormalTok{, }\DataTypeTok{size =} \DecValTok{16}\NormalTok{, }\DataTypeTok{hjust =} \FloatTok{0.5}\NormalTok{), }\CommentTok{#Centrer le titre de la carte}
+      \CommentTok{#Caractéristiques de la légende}
+      \DataTypeTok{legend.position =} \StringTok{"top"}\NormalTok{,                         }\CommentTok{#position de la légende}
+      \DataTypeTok{legend.title =} \KeywordTok{element_text}\NormalTok{(}\DataTypeTok{colour=}\StringTok{"blue"}\NormalTok{, }\DataTypeTok{size =} \DecValTok{11}\NormalTok{, }\DataTypeTok{face =} \StringTok{"bold"}\NormalTok{), }\CommentTok{#titre de la légende}
+      \DataTypeTok{legend.text =} \KeywordTok{element_text}\NormalTok{(}\DataTypeTok{size =} \DecValTok{10}\NormalTok{, }\DataTypeTok{face =} \StringTok{"italic"}\NormalTok{),               }\CommentTok{#texte des éléments de la légende}
+      \DataTypeTok{legend.background =} \KeywordTok{element_rect}\NormalTok{(}\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{linetype =} \StringTok{"solid"}\NormalTok{, }\DataTypeTok{colour =} \StringTok{"red"}\NormalTok{), }\CommentTok{#rectangle autour de la légende}
+      \DataTypeTok{legend.key =} \KeywordTok{element_rect}\NormalTok{(}\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{)        }\CommentTok{#couleur blanche sous les éléments de la légende}
 \NormalTok{)}
 \end{Highlighting}
 \end{Shaded}
 
-\begin{table}[t]
+\begin{figure}
 
-\caption{\label{tab:nice-tab}Here is a nice table!}
-\centering
-\begin{tabular}{rrrrl}
-\toprule
-Sepal.Length & Sepal.Width & Petal.Length & Petal.Width & Species\\
-\midrule
-5.1 & 3.5 & 1.4 & 0.2 & setosa\\
-4.9 & 3.0 & 1.4 & 0.2 & setosa\\
-4.7 & 3.2 & 1.3 & 0.2 & setosa\\
-4.6 & 3.1 & 1.5 & 0.2 & setosa\\
-5.0 & 3.6 & 1.4 & 0.2 & setosa\\
-\addlinespace
-5.4 & 3.9 & 1.7 & 0.4 & setosa\\
-4.6 & 3.4 & 1.4 & 0.3 & setosa\\
-5.0 & 3.4 & 1.5 & 0.2 & setosa\\
-4.4 & 2.9 & 1.4 & 0.2 & setosa\\
-4.9 & 3.1 & 1.5 & 0.1 & setosa\\
-\addlinespace
-5.4 & 3.7 & 1.5 & 0.2 & setosa\\
-4.8 & 3.4 & 1.6 & 0.2 & setosa\\
-4.8 & 3.0 & 1.4 & 0.1 & setosa\\
-4.3 & 3.0 & 1.1 & 0.1 & setosa\\
-5.8 & 4.0 & 1.2 & 0.2 & setosa\\
-\addlinespace
-5.7 & 4.4 & 1.5 & 0.4 & setosa\\
-5.4 & 3.9 & 1.3 & 0.4 & setosa\\
-5.1 & 3.5 & 1.4 & 0.3 & setosa\\
-5.7 & 3.8 & 1.7 & 0.3 & setosa\\
-5.1 & 3.8 & 1.5 & 0.3 & setosa\\
-\bottomrule
-\end{tabular}
-\end{table}
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-all2-1} 
 
-You can write citations, too. For example, we are using the
-\textbf{bookdown} package \citep{R-bookdown} in this sample book, which
-was built on top of R Markdown and \textbf{knitr} \citep{xie2015}.
+}
 
-\section{La représentation spatiale}\label{base}
+\caption{Types de voie cyclable et position des accidents routiers impliquant des bicyclettes sur l'île de Montréal.}\label{fig:plot-all2}
+\end{figure}
 
-\subsection{Les concepts de base}\label{les-concepts-de-base}
+La fonction \texttt{theme()} permet d'ajuster l'apparence de la carte (couleur du fond, couleur, taille et position du titre, format de la légende, etc.). Le chapitre \href{https://ggplot2.tidyverse.org/reference/theme.html}{Modify components of theme} \citep{Wickham_ggplot2_2016} énumère l'ensemble des paramètres pouvant être modifiés pour changer l'apparence d'une carte.
 
-\subsection{La représentation de données
-spatiales}\label{la-repruxe9sentation-de-donnuxe9es-spatiales}
+\hypertarget{reprojection-de-donnuxe9es-vectorielles-sous-r}{%
+\subsection{Reprojection de données vectorielles sous R}\label{reprojection-de-donnuxe9es-vectorielles-sous-r}}
 
-\subsection{Les systèmes de coordonnées de
-référence}\label{les-systuxe8mes-de-coordonnuxe9es-de-ruxe9fuxe9rence}
+Dans cette section vous apprendrez à manipuler le système de coordonnées de référence de données vectorielles. Nous avons vu en début de leçon que les données utilisées sont dans la projection de Mercator transverse (\texttt{tmerc}) et utilisent le Système de référence géodésique nord-américan de 1983 (\texttt{NAD83}). Par exemple, pour connaître le SCR des données \texttt{limites\_terrestres}, nous avions fait:
 
-\bibliography{book.bib,packages.bib}
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{st_crs}\NormalTok{(limites_terrestres)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{verbatim}
+Coordinate Reference System:
+  User input: 32188 
+  wkt:
+PROJCS["NAD83 / MTM zone 8",
+    GEOGCS["NAD83",
+        DATUM["North_American_Datum_1983",
+            SPHEROID["GRS 1980",6378137,298.257222101,
+                AUTHORITY["EPSG","7019"]],
+            TOWGS84[0,0,0,0,0,0,0],
+            AUTHORITY["EPSG","6269"]],
+        PRIMEM["Greenwich",0,
+            AUTHORITY["EPSG","8901"]],
+        UNIT["degree",0.0174532925199433,
+            AUTHORITY["EPSG","9122"]],
+        AUTHORITY["EPSG","4269"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",-73.5],
+    PARAMETER["scale_factor",0.9999],
+    PARAMETER["false_easting",304800],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AXIS["E(X)",EAST],
+    AXIS["N(Y)",NORTH],
+    AUTHORITY["EPSG","32188"]]
+\end{verbatim}
+
+Nous allons maintenant transformer le SCR vers la projection de Robinson (\texttt{robin}) et le Système géodésique mondial de 1984 (\texttt{WGS84}). Pour se faire nous utilisons la fonction \texttt{st\_transform} de la librarie \texttt{st}.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{limites_terrestres_rob <-}\StringTok{ }\KeywordTok{st_transform}\NormalTok{(limites_terrestres,}
+    \KeywordTok{CRS}\NormalTok{(}\StringTok{"+proj=robin +datum=WGS84"}\NormalTok{))}
+\end{Highlighting}
+\end{Shaded}
+
+Comparons les données transformées avec les données initiales. Pour se faire, nous voulons représenter les deux cartes une au-dessous de l'autre. La librarie \texttt{ggpubr} permet de créer facilement des figures avec des panneaux multiples. Installez la librarie si ce n'est pas déjà fait, et chargez-là dans votre session de travail.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\KeywordTok{library}\NormalTok{(ggpubr)}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{carte1<-}\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ limites_terrestres, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"white"}\NormalTok{) }\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Projection Mercator"}\NormalTok{)}
+\NormalTok{carte2<-}\KeywordTok{ggplot}\NormalTok{()}\OperatorTok{+}
+\StringTok{  }\KeywordTok{geom_sf}\NormalTok{(}\DataTypeTok{data =}\NormalTok{ limites_terrestres_rob, }\DataTypeTok{size =} \DecValTok{1}\NormalTok{, }\DataTypeTok{color =} \StringTok{"black"}\NormalTok{, }\DataTypeTok{fill =} \StringTok{"yellow"}\NormalTok{) }\OperatorTok{+}
+\StringTok{  }\KeywordTok{ggtitle}\NormalTok{(}\StringTok{"Projection Robinson"}\NormalTok{)}
+\NormalTok{figure <-}\StringTok{ }\KeywordTok{ggarrange}\NormalTok{(carte1, carte2, }\DataTypeTok{labels =} \KeywordTok{c}\NormalTok{(}\StringTok{"A"}\NormalTok{,}\StringTok{"B"}\NormalTok{),}\DataTypeTok{ncol =} \DecValTok{1}\NormalTok{, }\DataTypeTok{nrow =} \DecValTok{2}\NormalTok{)}
+\NormalTok{figure}
+\end{Highlighting}
+\end{Shaded}
+
+\begin{figure}
+
+{\centering \includegraphics[width=540px]{Cours_SpatialR_files/figure-latex/plot-terre2-1} 
+
+}
+
+\caption{Limites terrestres de l'île de Montréal selon les projections Mercartor (A) et Robinson (B)}\label{fig:plot-terre2}
+\end{figure}
+
+Finalement, pour sauvegarder des données vectorielles, nous utilisons la fonction \texttt{st\_write} de la librarie \texttt{st}, de la même façon que nous avons utilisé la fonction \texttt{st\_read} en début de leçon. Par exemple, sauvons les données \texttt{limites\_terrestres\_rob} que nous venons de créer.
+
+\begin{Shaded}
+\begin{Highlighting}[]
+\NormalTok{chemin<-}\StringTok{"D:/votrechemin/SCI1031/Module3/Donnees/"}
+\NormalTok{nom_du_fichier<-}\StringTok{ }\KeywordTok{paste}\NormalTok{(chemin, }\StringTok{"/Montreal_Velo/terre/terre_rob_shp.shp"}\NormalTok{, }\DataTypeTok{sep =} \StringTok{""}\NormalTok{)}
+\KeywordTok{st_read}\NormalTok{(limites_terrestres_rob,nom_du_fichier)}
+\end{Highlighting}
+\end{Shaded}
+
+\hypertarget{exercice-2}{%
+\section{Exercice}\label{exercice-2}}
+
+\hypertarget{mat}{%
+\chapter{Les données matricielles}\label{mat}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-3}{%
+\section{Leçon}\label{leuxe7on-3}}
+
+\hypertarget{introduction-aux-donnuxe9es-matricielles-sous-r}{%
+\subsection{Introduction aux données matricielles sous R}\label{introduction-aux-donnuxe9es-matricielles-sous-r}}
+
+\begin{itemize}
+\tightlist
+\item
+  Lire et explorer les attributs d'un raster
+\item
+  Comprendre le SCR
+\item
+  Gérer les données manquantes et les mauvaises données
+\item
+  Raster mono-bande et multi-bande
+\item
+  Écrire des données matricielles
+\end{itemize}
+
+\hypertarget{visualisation-de-rasters-sous-r}{%
+\subsection{Visualisation de rasters sous R}\label{visualisation-de-rasters-sous-r}}
+
+\begin{itemize}
+\tightlist
+\item
+  Utiliser ggplot pour visualiser les rasters
+\item
+  Visualiser plusieurs couches matricielles
+\item
+  Visualiser des données matricielles et vectorielles au sein d'une même figure
+\end{itemize}
+
+\hypertarget{reprojection-de-donnuxe9es-matricielles-sous-r}{%
+\subsection{Reprojection de données matricielles sous R}\label{reprojection-de-donnuxe9es-matricielles-sous-r}}
+
+\begin{itemize}
+\tightlist
+\item
+  Manipuler le SCR
+\item
+  Manipuler la résolution
+\end{itemize}
+
+\hypertarget{manipulation-de-rasters-multi-bande-sous-r}{%
+\subsection{Manipulation de rasters multi-bande sous R}\label{manipulation-de-rasters-multi-bande-sous-r}}
+
+\begin{itemize}
+\tightlist
+\item
+  Visualiser des rasters multi-bande
+\item
+  Manipuler des objets RasterStack
+\item
+  Manipuler des objets RasterBrick
+\end{itemize}
+
+\hypertarget{exercice-3}{%
+\section{Exercice}\label{exercice-3}}
+
+\hypertarget{carto}{%
+\chapter{La cartographie}\label{carto}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-4}{%
+\section{Leçon}\label{leuxe7on-4}}
+
+\hypertarget{cartographie-dobjets-vectoriels}{%
+\subsection{Cartographie d'objets vectoriels}\label{cartographie-dobjets-vectoriels}}
+
+\begin{itemize}
+\tightlist
+\item
+  Carte de base (graticules, échelle, rose des vents, légende, titre).
+\end{itemize}
+
+\hypertarget{cartographie-dobjets-matriciels}{%
+\subsection{Cartographie d'objets matriciels}\label{cartographie-dobjets-matriciels}}
+
+\begin{itemize}
+\tightlist
+\item
+  Carte de base, rampe de couleurs.
+\end{itemize}
+
+\hypertarget{cartographie-en-ligne}{%
+\subsection{Cartographie en ligne}\label{cartographie-en-ligne}}
+
+\begin{itemize}
+\tightlist
+\item
+  GoogleMap
+\item
+  Leaflet
+\item
+  OpenStreetMap
+\end{itemize}
+
+\hypertarget{exercice-4}{%
+\section{Exercice}\label{exercice-4}}
+
+\hypertarget{map_vec}{%
+\chapter{La manipulation de données vectorielles}\label{map_vec}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-5}{%
+\section{Leçon}\label{leuxe7on-5}}
+
+\hypertarget{opuxe9rations-de-base}{%
+\subsection{Opérations de base}\label{opuxe9rations-de-base}}
+
+\begin{itemize}
+\tightlist
+\item
+  Supprimer des champs, ajouter des champs, modifier des valeurs de champs, trier la table des attributs.
+\end{itemize}
+
+\hypertarget{opuxe9ration-sur-une-couche-vectorielle}{%
+\subsection{Opération sur une couche vectorielle}\label{opuxe9ration-sur-une-couche-vectorielle}}
+
+\begin{itemize}
+\tightlist
+\item
+  Jointure par identifiant, suppression de données, extraction par attributs, dissolution de polygones.
+\end{itemize}
+
+\hypertarget{opuxe9ration-sur-plusieurs-couches-vectorielles}{%
+\subsection{Opération sur plusieurs couches vectorielles}\label{opuxe9ration-sur-plusieurs-couches-vectorielles}}
+
+\begin{itemize}
+\tightlist
+\item
+  Combinaison de couches, jointure spatiale, intersection de couches, découpage d'une couche.
+\end{itemize}
+
+\hypertarget{exercice-5}{%
+\section{Exercice}\label{exercice-5}}
+
+\hypertarget{map_mat}{%
+\chapter{La manipulation de données matricielles}\label{map_mat}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-6}{%
+\section{Leçon}\label{leuxe7on-6}}
+
+\hypertarget{opuxe9rations-de-base-1}{%
+\subsection{Opérations de base}\label{opuxe9rations-de-base-1}}
+
+\begin{itemize}
+\tightlist
+\item
+  Création d'un raster, création d'un raster multi-couches, opérations mathématiques et statistiques élémentaires.
+\end{itemize}
+
+\hypertarget{opuxe9ration-sur-un-raster}{%
+\subsection{Opération sur un raster}\label{opuxe9ration-sur-un-raster}}
+
+\begin{itemize}
+\tightlist
+\item
+  Extraction d'un sous-ensemble de données, suppression de données, modification de données, changement de position
+\end{itemize}
+
+\hypertarget{opuxe9ration-sur-plusieurs-rasters}{%
+\subsection{Opération sur plusieurs rasters}\label{opuxe9ration-sur-plusieurs-rasters}}
+
+\begin{itemize}
+\tightlist
+\item
+  Combinaison de rasters, jointure spatiale, intersection de couches, découpage d'une couche.
+\end{itemize}
+
+\hypertarget{exercice-6}{%
+\section{Exercice}\label{exercice-6}}
+
+\hypertarget{spatiotemp}{%
+\chapter{Les données spatiotemporelles}\label{spatiotemp}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-7}{%
+\section{Leçon}\label{leuxe7on-7}}
+
+\hypertarget{propriuxe9tuxe9s-des-donnuxe9es-spatiotemporelles}{%
+\subsection{Propriétés des données spatiotemporelles}\label{propriuxe9tuxe9s-des-donnuxe9es-spatiotemporelles}}
+
+\hypertarget{introduction-uxe0-la-librairie-r-spacetime}{%
+\subsection{Introduction à la librairie R spacetime}\label{introduction-uxe0-la-librairie-r-spacetime}}
+
+\begin{itemize}
+\tightlist
+\item
+  Classes de données spatiotemporelles
+\item
+  Création d'objet ST
+\item
+  Manipulation de bases de données spatiotemporelles
+\end{itemize}
+
+\hypertarget{visualisation}{%
+\subsection{Visualisation}\label{visualisation}}
+
+\begin{itemize}
+\tightlist
+\item
+  Figure à panneaux multiples
+\item
+  Figure espace-temps
+\item
+  Figure animée
+\end{itemize}
+
+\hypertarget{exercice-7}{%
+\section{Exercice}\label{exercice-7}}
+
+\hypertarget{analyse}{%
+\chapter{L'analyse de données spatiales}\label{analyse}}
+
+L'objectif principal de ce module est
+
+À la fin de ce module vous saurez:
+
+\begin{itemize}
+\item
+\item
+\item
+\end{itemize}
+
+Vous utiliserez les librairies suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Vous apprendrez à utiliser les fonctions suivantes:
+
+\begin{itemize}
+\item
+\item
+\end{itemize}
+
+Dans la section Leçon, vous utiliserez des données XYXYX
+
+Dans la section Exercice, vous utiliserez XXXXX
+
+\hypertarget{leuxe7on-8}{%
+\section{Leçon}\label{leuxe7on-8}}
+
+\hypertarget{distance}{%
+\subsection{Distance}\label{distance}}
+
+\begin{itemize}
+\tightlist
+\item
+  Distance entre des points, distance entre des cellules, matrice de distance, distance pour les coordonnées angulaires.
+\end{itemize}
+
+\hypertarget{configuration-spatiale}{%
+\subsection{Configuration spatiale}\label{configuration-spatiale}}
+
+\begin{itemize}
+\tightlist
+\item
+  Proximité, plus proche voisin, frontière, superficie, connectivité, inclusion, zones tampons, matrice de résistance.
+\end{itemize}
+
+\hypertarget{autocorruxe9lation-spatiale}{%
+\subsection{Autocorrélation spatiale}\label{autocorruxe9lation-spatiale}}
+
+\begin{itemize}
+\tightlist
+\item
+  Covariance et correlation, autocorrelation temporelle et spatiale, indice de Moran.
+\end{itemize}
+
+\hypertarget{exercice-8}{%
+\section{Exercice}\label{exercice-8}}
+
+  \bibliography{refs.bib}
+
+\printindex
 
 \end{document}

--- a/Module2/index.Rmd
+++ b/Module2/index.Rmd
@@ -114,49 +114,49 @@ Voici une liste non-exhaustive de formats de données vectorielles.
   Le fichier d’index sert à lier entre elles les informations contenues dans les autres fichiers. Il existe parfois d’autres types de fichier d’index (.sbx, .sbn). Pour visualiser un *shapefile*, il est nécessaire d’avoir tous les fichiers associés (et pas seulement le fichier .shp). Le fichier .prj peut être absent. En son absence, le shapefile peut être lu mais les données ne seront pas projetées adéquatement. Nous reviendrons sur le concept de projection plus tard dans ce module.
 
 
-###### GEODATABASE {-}
+###### GEODATABASE (.GDB) {-}
 
-> La géodatabase est le nouveau format propriétaire d’ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au *shapefile*. Une géodatabase est une façon de rassembler et d’organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \@ref(fig:geodatabase)).
+ La géodatabase est le nouveau format propriétaire d’ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au *shapefile*. Une géodatabase est une façon de rassembler et d’organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \@ref(fig:geodatabase)).
 
 ```{r geodatabase, fig.align='left', echo=FALSE,fig.cap="Illustration d’une géodatabase telle que représentée sur le site web d’ArcGIS. Image récupérée à : https://desktop.arcgis.com/fr/arcmap/10.3/manage-data/geodatabases/a-quick-tour-of-the-geodatabase.htm", out.width = '50%'}
 knitr::include_graphics('Module2/images/2_geodatabase.PNG')
 ```
 
-> Par exemple, un projet sur le réseau de transport d’électricité au Québec pourrait nécessiter l’utilisation de plusieurs *shapefiles* (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s’avère beaucoup plus efficace d’avoir l’ensemble de ces données au sein d’une même base.
+ Par exemple, un projet sur le réseau de transport d’électricité au Québec pourrait nécessiter l’utilisation de plusieurs *shapefiles* (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s’avère beaucoup plus efficace d’avoir l’ensemble de ces données au sein d’une même base.
 
-> De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
+ De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
 
-> Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS.
+ Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS.
 
 
 ###### GEOGRAPHIC JAVASCRIPT OBJECT NOTATION (.GEOJSON, .JSON) {-}
 
-- Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information.
+ Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information.
 
 
 ###### GOOGLE KEYHOLE MARKUP LANGUAGE (.KML, .KMZ) {-}
 
-- Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).
+ Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).
 
 
 ###### COVERAGE {-}
 
-> COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
+ COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
 
 
 ###### ARCINFO INTERCHANGE FILE (.EOO) {-}
 
-> C'est le format utilisé pour importer ou exporter des données d’ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
+ C'est le format utilisé pour importer ou exporter des données d’ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
 
 
 ###### MAPINFO INTERCHANGE FILE (.MID, .MIF) {-}
 
->  C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
+ C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
 
 
 ###### WEB MAP SERVICE (WMS) {-}
 
-> N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
+ N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
 
 
 
@@ -231,25 +231,25 @@ Tout comme les données vectorielles, les données matricielles peuvent être st
 
 Voici une liste non-exhaustive de formats de données matricielles.
 
-> GRID (.GRD)
+###### GRID (.GRD)
 
   GRID est le format propriétaire d’ESRI pour stocker des données matricielles.
 
 
-> TIFF AND GEOTIFF (.TIF)
+###### TIFF AND GEOTIFF (.TIF)
 
   Le Tag Image File format (TIFF) est utilisé pour le stockage d’images numériques. Il a la particularité d’être comme un contenant dans lequel plusieurs informations additionnelles sur les données peuvent être stockées (par ex. les attributs, et autres métadonnées).
 Le format GeoTIFF est un fichier .tif standard dans lequel on intègre des informations additionnelles sur la localisation spatiale des données (p. ex. la résolution, l’étendue ou le système de coordonnées géographiques).
 
 
-> COMMA SEPERATED VALUE FORTMAT (.CSV)
+###### COMMA SEPERATED VALUE FORTMAT (.CSV)
 
   Le format .csv contient du texte séparé par des virgules, et correspond à une façon simple et très répandue de représenter des données matricielles. Par exemple, un fichier .csv pourrait être constitué de trois colonnes : la première pour la coordonnée x de la cellule, la deuxième pour sa coordonnée y, et la troisième pour la valeur de l’attribut.
 
   Une autre façon d’utiliser le format .csv est d’y stocker la matrice de données sous forme d’un tableau de dimension égale à cette dernière. Chaque entrée du tableau donne la valeur d’attribut pour la cellule correspondante. Les informations sur la localisation spatiale doivent alors être fournies en en-tête du fichier.
 
 
-> BITMAP (.BMP)
+###### BITMAP (.BMP)
 
   BITMAP est le format d’images utilisé dans les applications de Microsoft Windows.
 

--- a/Module2/index.Rmd
+++ b/Module2/index.Rmd
@@ -2,7 +2,7 @@
 
 
 
-Ce module s’intéresse à la façon dont nous représentons les phénomènes spatiaux se déroulant à la surface de la Terre par des données spatiales. Les objectifs principaux sont de connaître les propriétés des deux types de données spatiales, les données vectorielles et les données matricielles, et de savoir interpréter le système de coordonnées de référence de données spatiales.  
+Ce module s’intéresse à la façon dont nous représentons les phénomènes spatiaux se déroulant à la surface de la Terre par des données spatiales. Les objectifs principaux sont de connaître les propriétés des deux types de données spatiales, les données vectorielles et les données matricielles, et de savoir interpréter le système de coordonnées de référence de données spatiales.
 
 À la fin de ce module vous saurez:
 
@@ -14,7 +14,7 @@ Ce module s’intéresse à la façon dont nous représentons les phénomènes s
 
 
 
-Dans la section Exercice, vous réaliserez une auto-évaluation pour vérifier votre acquisition des connaissances enseignées dans ce module. 
+Dans la section Exercice, vous réaliserez une auto-évaluation pour vérifier votre acquisition des connaissances enseignées dans ce module.
 
 
 ## Leçon
@@ -22,25 +22,25 @@ Dans la section Exercice, vous réaliserez une auto-évaluation pour vérifier v
 
 ### La représentation de données spatiales
 
-Les  phénomènes spatiaux sont généralement perçus comme étant soit des entités discrètes avec des frontières bien définies ou encore comme des phénomènes continus qu’on observe de partout mais qui ne possèdent pas de frontières naturelles^[Repris de l'introduction aux données spatiales du site [Spatial Data Science](https://rspatial.org/raster/spatial/2-spatialdata.html).]. Une rivière, une route, un pays, ou une ville sont tous des exemples d’entités spatiales discrètes (\@ref(fig:vectomat)a). D’autre part, l’élévation, la température ou la qualité de l’air sont des exemples de phénomènes continus, appelés aussi des champs spatiaux (\@ref(fig:vectomat)b). 
- 
-```{r vectomat, fig.align='left', echo=FALSE,fig.cap="Exemples de données vectorielles et matricielles : a) La carte délimitant les régions administratives du Québec est formée à partir de données vectorielles; b) La carte topographique du Québec (source : [https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/)](https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/))", out.width = '100%'}
+Les phénomènes spatiaux sont généralement perçus comme étant soit des entités discrètes avec des frontières bien définies ou encore comme des phénomènes continus qu’on observe de partout mais qui ne possèdent pas de frontières naturelles^[Repris de l'introduction aux données spatiales du site [Spatial Data Science](https://rspatial.org/raster/spatial/2-spatialdata.html).]. Une rivière, une route, un pays, ou une ville sont tous des exemples d’entités spatiales discrètes (\@ref(fig:vectomat)a). D’autre part, l’élévation, la température ou la qualité de l’air sont des exemples de phénomènes continus, appelés aussi des champs spatiaux (\@ref(fig:vectomat)b).
+
+```{r vectomat, fig.align='left', echo=FALSE, fig.cap="Exemples de données vectorielles et matricielles : a) La carte délimitant les régions administratives du Québec est formée à partir de données vectorielles; b) La carte topographique du Québec (source : [https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/)](https://mern.gouv.qc.ca/repertoire-geographique/carte-relief-quebec/))", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_vecto_vs_mat.png')
 ```
 
 
-Les entités spatiales (ou objets) sont habituellement représentés par ce qu’on appelle des données vectorielles (« vector data », en anglais), alors que les phénomènes continues sont habituellement représentés par des données matricielles (« raster data », en anglais).  Ces deux modèles sont des façons bien différentes de percevoir et de représenter les phénomènes spatiaux. Nous les décrivons dans les deux sous-sections suivantes. 
+Les entités spatiales (ou objets) sont habituellement représentés par ce qu’on appelle des données vectorielles (« vector data », en anglais), alors que les phénomènes continues sont habituellement représentés par des données matricielles (« raster data », en anglais).  Ces deux modèles sont des façons bien différentes de percevoir et de représenter les phénomènes spatiaux. Nous les décrivons dans les deux sous-sections suivantes.
 
 
-#### Les données vectorielles 
+#### Les données vectorielles
 
 ##### Définition {-}
 
-Les données vectorielles sont utilisées pour représenter des entités spatiales dont les frontières sont explicites et qui possède une localisation précise et unique. Les données vectorielles sont définies par leur localisation géographique, leur géométrie, et un ou plusieurs attributs. 
+Les données vectorielles sont utilisées pour représenter des entités spatiales dont les frontières sont explicites et qui possède une localisation précise et unique. Les données vectorielles sont définies par leur localisation géographique, leur géométrie, et un ou plusieurs attributs.
 
 La **localisation géographique** désigne l’emplacement de l’entité selon un système de coordonnées géographiques  ou un système de coordonnées projetées. Un système de coordonnées géographiques utilise un système en trois dimensions pour donner la position (x,y,z) ou longitude et latitude d’une entité spatiale sur la surface sphérique de la Terre. Un système de coordonnées projetées, donne la position d’une entité spatiale sur une surface plane à deux dimensions. Nous reviendrons sur les systèmes de coordonnées de référence à la section 2.1.3.
 
-La **géométrie** d’une entité spatiale correspond à sa forme (« shape », en anglais). Il existe trois principaux types de géométrie, aussi appelées des classes : les points, les lignes, et les polygones  (Tableau \@ref(fig:geometriesimple)). Ces classes peuvent être combinées pour créer des géométries plus complexes; des multipoints, des multilignes, des multipolygones, etc. 
+La **géométrie** d’une entité spatiale correspond à sa forme (« shape », en anglais). Il existe trois principaux types de géométrie, aussi appelées des classes : les points, les lignes, et les polygones  (Tableau \@ref(fig:geometriesimple)). Ces classes peuvent être combinées pour créer des géométries plus complexes; des multipoints, des multilignes, des multipolygones, etc.
 
 
 ```{r geometriesimple, fig.align='left', echo=FALSE,fig.cap="Exemple de données vectorielles de géométrie simple. Remarquez que dans le cas d’un polygone, la première et la dernière coordonnées sont les mêmes. Tableau inspiré de Wikipedia (https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry)", out.width = '80%'}
@@ -48,61 +48,61 @@ knitr::include_graphics('Module2/images/2_geometriesimple.png')
 ```
 
 
-Les données vectorielles comprennent également des variables additionnelles appelées des **attributs**. Les attributs sont toutes informations permettant de décrire une entité spatiale autres que sa localisation et sa géométrie. 
+Les données vectorielles comprennent également des variables additionnelles appelées des **attributs**. Les attributs sont toutes informations permettant de décrire une entité spatiale autres que sa localisation et sa géométrie.
 
 ##### Géométrie et topologie {-}
 
-Les **points** sont les données vectorielles les plus simples. Par exemple, un point pourrait représenter l’emplacement d’un restaurant dans une ville. Les attributs associés à ce point pourraient inclure les heures d’ouverture, sa spécialité culinaire, l’échelle de prix de son menu ou d’autres informations. 
+Les **points** sont les données vectorielles les plus simples. Par exemple, un point pourrait représenter l’emplacement d’un restaurant dans une ville. Les attributs associés à ce point pourraient inclure les heures d’ouverture, sa spécialité culinaire, l’échelle de prix de son menu ou d’autres informations.
 
 ```{r multipoints, fig.align='left', echo=FALSE,fig.cap="L’emplacement des stations de vélo en libre partage, *Bixi*, dans un quartier de Montréal correspond à une géométrie multipoints. Source : https://secure.bixi.com/map/", out.width = '60%'}
 knitr::include_graphics('Module2/images/2_multipoints.PNG')
 ```
 
-Il est aussi possible de combiner plusieurs points ensemble dans une structure multipoints définie par un attribut unique (Figure \@ref(fig:multipoints)). Par exemple, l’ensemble des restaurants de cuisine vietnamienne dans une ville pourrait être considéré comme une géométrie unique. 
+Il est aussi possible de combiner plusieurs points ensemble dans une structure multipoints définie par un attribut unique (Figure \@ref(fig:multipoints)). Par exemple, l’ensemble des restaurants de cuisine vietnamienne dans une ville pourrait être considéré comme une géométrie unique.
 
-La géométrie des **lignes** est plus complexe. Le terme ligne en analyse spatiale n’a pas la même définition que dans le langage usuel. Une ligne désigne un ensemble d’une seule ou de plusieurs polylignes (Figure \@ref(fig:multilignes)). Une polyligne, quant à elle, désigne une séquence de segments de droite reliés entre eux. Ainsi, en analyse spatiale, une seule ligne pourrait représenter le fleuve Saint-Laurent et l’ensemble de ces affluents (rivière des Outaouais, rivière Saint-Maurice, le Fjord du Saguenay, etc.). D’autre part, il serait aussi possible de définir plusieurs lignes – une pour chaque affluent, par exemple. 
+La géométrie des **lignes** est plus complexe. Le terme ligne en analyse spatiale n’a pas la même définition que dans le langage usuel. Une ligne désigne un ensemble d’une seule ou de plusieurs polylignes (Figure \@ref(fig:multilignes)). Une polyligne, quant à elle, désigne une séquence de segments de droite reliés entre eux. Ainsi, en analyse spatiale, une seule ligne pourrait représenter le fleuve Saint-Laurent et l’ensemble de ces affluents (rivière des Outaouais, rivière Saint-Maurice, le Fjord du Saguenay, etc.). D’autre part, il serait aussi possible de définir plusieurs lignes – une pour chaque affluent, par exemple.
 
 ```{r multilignes, fig.align='left', echo=FALSE,fig.cap="Le réseau hydrologique du bassin de l’Amazone représente un exemple d’un ensemble de polylignes. Source : Wang et al. 2020.", out.width = '60%'}
 knitr::include_graphics('Module2/images/2_multilignes.png')
 ```
 
-Une ligne est représentée par un ensemble ordonné de coordonnées. Les segments de droite peuvent être calculés ou dessinés sur une carte en connectant ensemble les points. Ainsi, la représentation d’une ligne est semblable à celle d’une structure multipoints. La différence notable est que l’ordre des points est important dans la représentation d’une ligne car il est nécessaire de savoir quels points sont connectés entre eux. 
+Une ligne est représentée par un ensemble ordonné de coordonnées. Les segments de droite peuvent être calculés ou dessinés sur une carte en connectant ensemble les points. Ainsi, la représentation d’une ligne est semblable à celle d’une structure multipoints. La différence notable est que l’ordre des points est important dans la représentation d’une ligne car il est nécessaire de savoir quels points sont connectés entre eux.
 
 Un réseau – par exemple un réseau routier ou un réseau hydrographique – est une ligne de géométrie particulière comprenant des informations additionnelles comme le débit, la connectivité ou la distance.
 
-Un **polygone** désigne un ensemble de polylignes fermées. La géométrie d’un polygone est très semblable à celle des lignes à l’exception que la dernière paire de coordonnées doit coïncider avec la première paire afin de « fermer » le polygone.  
+Un **polygone** désigne un ensemble de polylignes fermées. La géométrie d’un polygone est très semblable à celle des lignes à l’exception que la dernière paire de coordonnées doit coïncider avec la première paire afin de « fermer » le polygone.
 
-Une particularité des polygones est qu’ils peuvent comprendre des trous. C’est-à-dire qu’un polygone peut être entièrement compris à l’intérieur d’un polygone de plus grande superficie. Ceci est le cas d’une île au sein d’un lac, par exemple. Le polygone formant un îlot permet d’éliminer une partie du polygone qui l’englobe. De plus, alors que l’auto-intersection est permise pour une ligne (c’est-à-dire qu’elle peut se croiser sur elle-même), cette propriété n’est pas valide pour un polygone. 
+Une particularité des polygones est qu’ils peuvent comprendre des trous. C’est-à-dire qu’un polygone peut être entièrement compris à l’intérieur d’un polygone de plus grande superficie. Ceci est le cas d’une île au sein d’un lac, par exemple. Le polygone formant un îlot permet d’éliminer une partie du polygone qui l’englobe. De plus, alors que l’auto-intersection est permise pour une ligne (c’est-à-dire qu’elle peut se croiser sur elle-même), cette propriété n’est pas valide pour un polygone.
 
-Finalement, plusieurs polygones peuvent être considérés comme formant une géométrie unique ((Figure \@ref(fig:multipolygones))). Par exemple, l’Indonésie est constituée de plusieurs îles. Chaque île peut être représentée par son propre polygone, ou encore l’ensemble des îles peut être représenté par un seul polygone (ou multi-polygones) désignant le pays en entier. 
- 
+Finalement, plusieurs polygones peuvent être considérés comme formant une géométrie unique ((Figure \@ref(fig:multipolygones))). Par exemple, l’Indonésie est constituée de plusieurs îles. Chaque île peut être représentée par son propre polygone, ou encore l’ensemble des îles peut être représenté par un seul polygone (ou multi-polygones) désignant le pays en entier.
+
 
 ```{r multipolygones, fig.align='left', echo=FALSE,fig.cap="Les Antilles peuvent être représentées par plusieurs polygones distincts pour chaque île, ou par un seul multipolygone. Source : https://fr.wikipedia.org/wiki/Antilles", out.width = '50%'}
 knitr::include_graphics('Module2/images/2_multipolygones.png')
 ```
 
 
-Le modèle vectoriel est très efficace pour représenter la **topologie**. La topologie est une description des relations spatiales qu’ont les entités spatiales entre elles. Par exemple, une analyse de données vectorielles permettra de déterminer précisément si une entité spatiale est adjacente à une autre, si elle y est incluse, ou si elle s’intersecte (Figure \@ref(fig:relationsspatiales)). 
+Le modèle vectoriel est très efficace pour représenter la **topologie**. La topologie est une description des relations spatiales qu’ont les entités spatiales entre elles. Par exemple, une analyse de données vectorielles permettra de déterminer précisément si une entité spatiale est adjacente à une autre, si elle y est incluse, ou si elle s’intersecte (Figure \@ref(fig:relationsspatiales)).
 
-```{r relationsspatiales, fig.align='left', echo=FALSE,fig.cap="Exemples de relations spatiales entre deux entités spatiales : a) adjacence, b) inclusion, et c) intersection.", out.width = '100%'}
+```{r relationsspatiales, fig.align='left', echo=FALSE, fig.cap="Exemples de relations spatiales entre deux entités spatiales : a) adjacence, b) inclusion, et c) intersection.", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_relationsspatiales.png')
 ```
 
 ##### Format de données vectorielles {-}
 
-Les données vectorielles peuvent être stockées dans une grande variété de formats différents. Ces formats ont évolué et continuent d’évoluer en fonction des besoins et des avancées technologiques. Plusieurs formats ont été développés pour être utilisés avec des logiciels commerciaux mais peuvent être lus et parfois édités par d’autres logiciels. 
+Les données vectorielles peuvent être stockées dans une grande variété de formats différents. Ces formats ont évolué et continuent d’évoluer en fonction des besoins et des avancées technologiques. Plusieurs formats ont été développés pour être utilisés avec des logiciels commerciaux mais peuvent être lus et parfois édités par d’autres logiciels.
 
-Peu importe leur format, les données vectorielles sont toujours organisées selon une *base de données relationnelle*. Un identifiant désigne chaque objet spatial et l’associe à une géométrie et à un ou plusieurs attributs (Tableau \@ref(fig:baserelationnelle)). 
+Peu importe leur format, les données vectorielles sont toujours organisées selon une *base de données relationnelle*. Un identifiant désigne chaque objet spatial et l’associe à une géométrie et à un ou plusieurs attributs (Tableau \@ref(fig:baserelationnelle)).
 
-```{r baserelationnelle, fig.align='left', echo=FALSE,fig.cap="Exemple d’une base de données relationnelle pour la carte des régions administratives du Québec (Figure ref(fig:vectomat)a). Chaque objet vectoriel dans la carte correspond à une ligne dans la base de données où figurent les attributs qui lui sont associés", out.width = '100%'}
+```{r baserelationnelle, fig.align='left', echo=FALSE, fig.cap="Exemple d’une base de données relationnelle pour la carte des régions administratives du Québec (Figure \\@ref(fig:vectomat)a). Chaque objet vectoriel dans la carte correspond à une ligne dans la base de données où figurent les attributs qui lui sont associés", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_baserelationnelle.png')
 ```
 
 Voici une liste non-exhaustive de formats de données vectorielles.
 
-> SHAPEFILE (.SHP, .DBF, .PRJ, .SHX)
+###### SHAPEFILE (.SHP, .DBF, .PRJ, .SHX) {-}
 
-  Le *shapefile* est un format propriétaire d’ESRI créé pour les logiciels ArcView et ArcGIS. En français, on le nomme aussi un fichier de forme. À ce jour, il est le format le plus couramment utilisé pour les données vectorielles. Il est devenu un standard tant pour les plateformes commerciales qu’opensource. 
+  Le *shapefile* est un format propriétaire d’ESRI créé pour les logiciels ArcView et ArcGIS. En français, on le nomme aussi un fichier de forme. À ce jour, il est le format le plus couramment utilisé pour les données vectorielles. Il est devenu un standard tant pour les plateformes commerciales qu’opensource.
 
   Un *shapefile* comprend entre quatre types de fichiers qui contiennent des informations différentes et toutes essentielles à sa représentation.
 
@@ -111,69 +111,69 @@ Voici une liste non-exhaustive de formats de données vectorielles.
   -	.prj : contient l’information sur la projection des données
   -	.shx : fichier d’index
 
-  Le fichier d’index sert à lier entre elles les informations contenues dans les autres fichiers. Il existe parfois d’autres types de fichier d’index (.sbx, .sbn). Pour visualiser un *shapefile*, il est nécessaire d’avoir tous les fichiers associés (et pas seulement le fichier .shp). Le fichier .prj peut être absent. En son absence, le shapefile peut être lu mais les données ne seront pas projetées adéquatement. Nous reviendrons sur le concept de projection plus tard dans ce module. 
-  
+  Le fichier d’index sert à lier entre elles les informations contenues dans les autres fichiers. Il existe parfois d’autres types de fichier d’index (.sbx, .sbn). Pour visualiser un *shapefile*, il est nécessaire d’avoir tous les fichiers associés (et pas seulement le fichier .shp). Le fichier .prj peut être absent. En son absence, le shapefile peut être lu mais les données ne seront pas projetées adéquatement. Nous reviendrons sur le concept de projection plus tard dans ce module.
 
-> GEODATABASE
+
+###### GEODATABASE {-}
 
   La géodatabase est le nouveau format propriétaire d’ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au *shapefile*. Une géodatabase est une façon de rassembler et d’organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \@ref(fig:geodatabase)).
- 
+
 ```{r geodatabase, fig.align='left', echo=FALSE,fig.cap="Illustration d’une géodatabase telle que représentée sur le site web d’ArcGIS. Image récupérée à : https://desktop.arcgis.com/fr/arcmap/10.3/manage-data/geodatabases/a-quick-tour-of-the-geodatabase.htm", out.width = '50%'}
 knitr::include_graphics('Module2/images/2_geodatabase.PNG')
 ```
 
   Par exemple, un projet sur le réseau de transport d’électricité au Québec pourrait nécessiter l’utilisation de plusieurs *shapefiles* (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s’avère beaucoup plus efficace d’avoir l’ensemble de ces données au sein d’une même base.
 
-  De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.  
+  De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
 
-  Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS. 
-  
+  Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS.
 
-> GEOGRAPHIC JAVASCRIPT OBJECT NOTATION (.GEOJSON, .JSON)
 
-  Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information. 
-  
+###### GEOGRAPHIC JAVASCRIPT OBJECT NOTATION (.GEOJSON, .JSON) {-}
 
-> GOOGLE KEYHOLE MARKUP LANGUAGE (.KML, .KMZ)
+  Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information.
 
-  Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).  
-  
 
-> COVERAGE
+###### GOOGLE KEYHOLE MARKUP LANGUAGE (.KML, .KMZ) {-}
 
-  COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990. 
-  
+  Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).
 
-> ARCINFO INTERCHANGE FILE (.EOO)
+
+###### COVERAGE {-}
+
+  COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
+
+
+###### ARCINFO INTERCHANGE FILE (.EOO) {-}
 
   C'est le format utilisé pour importer ou exporter des données d’ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
-  
 
-> MAPINFO INTERCHANGE FILE (.MID, .MIF)
 
-  C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.  
-  
+###### MAPINFO INTERCHANGE FILE (.MID, .MIF) {-}
 
-> WEB MAP SERVICE (WMS)
+  C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
 
-  N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles. 
-  
-  
 
-#### Les données matricielles 
+###### WEB MAP SERVICE (WMS) {-}
+
+  N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
+
+
+
+#### Les données matricielles
 
 ##### Définition {-}
 
-Les données matricielles représentent la surface terrestre par une grille régulière, communément appelé un raster, formée de rectangles de même forme et de même dimension appelés cellules ou pixels (Figure \@ref(fig:raster)). À chaque cellule de la matrice est associée une valeur numérique (ou une valeur manquante) associée à un attribut d’intérêt. On appelle couche (« layer » en anglais) l’information recueillie dans la matrice. 
+Les données matricielles représentent la surface terrestre par une grille régulière, communément appelé un raster, formée de rectangles de même forme et de même dimension appelés cellules ou pixels (Figure \@ref(fig:raster)). À chaque cellule de la matrice est associée une valeur numérique (ou une valeur manquante) associée à un attribut d’intérêt. On appelle couche (« layer » en anglais) l’information recueillie dans la matrice.
 
-La valeur d’une cellule peut être continue (p. ex. l’élévation - voir Figure \@ref(fig:vectomat)b) ou catégorique (p. ex. le zonage attribué à différents secteurs d’une ville tel que résidentiel, commercial ou industriel). Normalement, la valeur d’une cellule représente la valeur moyenne (ou la valeur prédominante) pour la superficie qu’elle couvre. Cependant, les valeurs sont parfois estimées pour le centre de la cellule. 
+La valeur d’une cellule peut être continue (p. ex. l’élévation - voir Figure \@ref(fig:vectomat)b) ou catégorique (p. ex. le zonage attribué à différents secteurs d’une ville tel que résidentiel, commercial ou industriel). Normalement, la valeur d’une cellule représente la valeur moyenne (ou la valeur prédominante) pour la superficie qu’elle couvre. Cependant, les valeurs sont parfois estimées pour le centre de la cellule.
 
- 
+
 ```{r raster, fig.align='left', echo=FALSE,fig.cap="Exemple de données matricielles associées à des classes de végétation obtenues à partir d’une image satellitaire. Figure inspirée de NEON neonscience.org/resources/series/introduction-working-raster-data-r", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_raster.png')
 ```
 
-On peut utiliser une base de données relationnelle pour lier la valeur d’un pixel à l’attribut qu’il décrit (Figure  \@ref(fig:rastertable)). Contrairement aux données vectorielles où les polygones peuvent être associés à plusieurs attributs, une couche de données matricielles peut représenter un seul attribut.  
+On peut utiliser une base de données relationnelle pour lier la valeur d’un pixel à l’attribut qu’il décrit (Figure  \@ref(fig:rastertable)). Contrairement aux données vectorielles où les polygones peuvent être associés à plusieurs attributs, une couche de données matricielles peut représenter un seul attribut.
 
 ```{r rastertable, fig.align='left', echo=FALSE,fig.cap="Exemple de table relationnelle pour les données vectorielles de la Figure ref(fig:raster). Une valeur numérique est associée à chaque couleur de l’image ainsi qu’à un attribut, ici le type de végétation", out.width = '80%'}
 knitr::include_graphics('Module2/images/2_raster_table.png')
@@ -185,7 +185,7 @@ La localisation pour des données matricielles est définie par **l’étendue s
 
 ##### Résolution et géométrie {-}
 
-La **résolution** définie la précision avec laquelle nous pouvons discerner les objets dans l’espace. Une grande résolution correspond à une matrice de données dont les cellules ont une petite taille (Figure \@ref(fig:resolution)). En conséquence, une telle matrice est plus lente à visualiser et à manipuler, et requière un fichier plus volumineux. En contrepartie, une couche de données matricielles de faible résolution possède des cellules de plus grande taille, se visualise et se manipule plus rapidement, et est contenue dans un fichier moins volumineux. 
+La **résolution** définie la précision avec laquelle nous pouvons discerner les objets dans l’espace. Une grande résolution correspond à une matrice de données dont les cellules ont une petite taille (Figure \@ref(fig:resolution)). En conséquence, une telle matrice est plus lente à visualiser et à manipuler, et requière un fichier plus volumineux. En contrepartie, une couche de données matricielles de faible résolution possède des cellules de plus grande taille, se visualise et se manipule plus rapidement, et est contenue dans un fichier moins volumineux.
 
 ```{r resolution, fig.align='left', echo=FALSE,fig.cap="Exemple du concept de résolution: plus la résolution est grande, plus la taille des cellules est petite. Dans cette figure, la résolution diminue de droite à gauche, et la taille des cellules augmente. Source de données: https://mern.gouv.qc.ca/nos-publications/spatiocarte-quebec/", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_resolution.png')
@@ -198,13 +198,13 @@ Contrairement aux données vectorielles, la géométrie des données matricielle
 knitr::include_graphics('Module2/images/2_raster_boundary.png')
 ```
 
-Ainsi, lorsque nous représentons des objets spatiaux aux frontières bien définies, l’utilisation de données vectorielles plutôt que matricielles s’avère plus précise et plus efficace. 
+Ainsi, lorsque nous représentons des objets spatiaux aux frontières bien définies, l’utilisation de données vectorielles plutôt que matricielles s’avère plus précise et plus efficace.
 
 Par ailleurs, la représentation de phénomènes continus avec des données vectorielles, nécessiterait de définir un grand nombre de petit polygones et d’enregistrer les coordonnées de chacun d’eux. Dans la majorité des cas, une telle représentation augmenterait dramatiquement le temps de traitement des données.
 
 ##### Données matricielles à bande unique et multi-bandes {-}
 
-Un *raster* peut contenir une couche ou plusieurs couches de données. Par exemple, un fichier de données matricielles d’élévation comprendra une seule couche de données, soit l’élévation à chaque cellule. Par exemple la carte topographique du Québec (Figure \@ref(fig:vectomat)b) est un exemple de raster à une seule couche.  
+Un *raster* peut contenir une couche ou plusieurs couches de données. Par exemple, un fichier de données matricielles d’élévation comprendra une seule couche de données, soit l’élévation à chaque cellule. Par exemple la carte topographique du Québec (Figure \@ref(fig:vectomat)b) est un exemple de raster à une seule couche.
 
 Un raster à une seule couche peut aussi représenter des images en noir et blanc en utilisant un codage binaire pour exprimer différentes teintes de gris. Un codage sur 1 bit exprimera 2<sup>1</sup> (2) teintes de gris [0,1], un codage sur 4 bit exprimera 2<sup>4</sup> (16) teintes de gris [0,1,2,…,15], et un codage sur 16 bits exprimera 2<sup>16</sup> (65536) teintes de gris [0,1,2,…, 65535] (Figure \@ref(fig:binaire)).
 
@@ -219,7 +219,7 @@ knitr::include_graphics('Module2/images/2_electromagnetic_spectrum.png')
 ```
 
 
-En combinant ces bandes, on peut recréer l’image (Figure \@ref(fig:3bands)). Attention : chaque bande doit posséder les mêmes informations spatiales pour être superposée aux autres. 
+En combinant ces bandes, on peut recréer l’image (Figure \@ref(fig:3bands)). Attention : chaque bande doit posséder les mêmes informations spatiales pour être superposée aux autres.
 
 ```{r 3bands, fig.align='left', echo=FALSE,fig.cap="Image satellitaire de région de l’Estrie. Le raster multi-bande contient une bande de rouge, une bande de vert et une bande de bleu. L’image couleur s’obtient en combinant les trois bandes.  Source de données: https://mern.gouv.qc.ca/nos-publications/spatiocarte-quebec/", out.width = '100%'}
 knitr::include_graphics('Module2/images/2_3bands.png')
@@ -233,28 +233,28 @@ Voici une liste non-exhaustive de formats de données matricielles.
 
 > GRID (.GRD)
 
-  GRID est le format propriétaire d’ESRI pour stocker des données matricielles. 
-  
+  GRID est le format propriétaire d’ESRI pour stocker des données matricielles.
+
 
 > TIFF AND GEOTIFF (.TIF)
-  
-  Le Tag Image File format (TIFF) est utilisé pour le stockage d’images numériques. Il a la particularité d’être comme un contenant dans lequel plusieurs informations additionnelles sur les données peuvent être stockées (par ex. les attributs, et autres métadonnées). 
-Le format GeoTIFF est un fichier .tif standard dans lequel on intègre des informations additionnelles sur la localisation spatiale des données (p. ex. la résolution, l’étendue ou le système de coordonnées géographiques). 
+
+  Le Tag Image File format (TIFF) est utilisé pour le stockage d’images numériques. Il a la particularité d’être comme un contenant dans lequel plusieurs informations additionnelles sur les données peuvent être stockées (par ex. les attributs, et autres métadonnées).
+Le format GeoTIFF est un fichier .tif standard dans lequel on intègre des informations additionnelles sur la localisation spatiale des données (p. ex. la résolution, l’étendue ou le système de coordonnées géographiques).
 
 
 > COMMA SEPERATED VALUE FORTMAT (.CSV)
 
-  Le format .csv contient du texte séparé par des virgules, et correspond à une façon simple et très répandue de représenter des données matricielles. Par exemple, un fichier .csv pourrait être constitué de trois colonnes : la première pour la coordonnée x de la cellule, la deuxième pour sa coordonnée y, et la troisième pour la valeur de l’attribut. 
-  
-  Une autre façon d’utiliser le format .csv est d’y stocker la matrice de données sous forme d’un tableau de dimension égale à cette dernière. Chaque entrée du tableau donne la valeur d’attribut pour la cellule correspondante. Les informations sur la localisation spatiale doivent alors être fournies en en-tête du fichier. 
-  
-  
+  Le format .csv contient du texte séparé par des virgules, et correspond à une façon simple et très répandue de représenter des données matricielles. Par exemple, un fichier .csv pourrait être constitué de trois colonnes : la première pour la coordonnée x de la cellule, la deuxième pour sa coordonnée y, et la troisième pour la valeur de l’attribut.
+
+  Une autre façon d’utiliser le format .csv est d’y stocker la matrice de données sous forme d’un tableau de dimension égale à cette dernière. Chaque entrée du tableau donne la valeur d’attribut pour la cellule correspondante. Les informations sur la localisation spatiale doivent alors être fournies en en-tête du fichier.
+
+
 > BITMAP (.BMP)
 
   BITMAP est le format d’images utilisé dans les applications de Microsoft Windows.
 
 
-De plus, comme expliqué plus haut, la géodatabase et Web Map Service sont aussi utilisés pour les données matricielles. 
+De plus, comme expliqué plus haut, la géodatabase et Web Map Service sont aussi utilisés pour les données matricielles.
 
 
 Peu importe le type de données spatiales et le format utilisé pour les stocker, les données spatiales sont souvent accompagnées de **métadonnées**. Les métadonnées sont les données sur les données. C’est-à-dire qu’elles viennent donner des informations supplémentaires pour faciliter la compréhension et l’utilisation des données spatiales (p. ex. l’origine des données, l’auteur.e, les détails sur la structure, le lexique, les abréviations, la légende, etc.). Idéalement, tout ensemble de données devrait être accompagné de métadonnées.

--- a/Module2/index.Rmd
+++ b/Module2/index.Rmd
@@ -116,47 +116,47 @@ Voici une liste non-exhaustive de formats de données vectorielles.
 
 ###### GEODATABASE {-}
 
-  La géodatabase est le nouveau format propriétaire d’ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au *shapefile*. Une géodatabase est une façon de rassembler et d’organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \@ref(fig:geodatabase)).
+> La géodatabase est le nouveau format propriétaire d’ESRI conçu pour ArcGIS. Il est de plus en plus adopté car il présente de nombreux avantages par rapport au *shapefile*. Une géodatabase est une façon de rassembler et d’organiser des données propres à un sujet ou à un projet dans une unique base de données. Elle peut contenir des données géographiques dans une large gamme de fichiers et de formats (Figure \@ref(fig:geodatabase)).
 
 ```{r geodatabase, fig.align='left', echo=FALSE,fig.cap="Illustration d’une géodatabase telle que représentée sur le site web d’ArcGIS. Image récupérée à : https://desktop.arcgis.com/fr/arcmap/10.3/manage-data/geodatabases/a-quick-tour-of-the-geodatabase.htm", out.width = '50%'}
 knitr::include_graphics('Module2/images/2_geodatabase.PNG')
 ```
 
-  Par exemple, un projet sur le réseau de transport d’électricité au Québec pourrait nécessiter l’utilisation de plusieurs *shapefiles* (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s’avère beaucoup plus efficace d’avoir l’ensemble de ces données au sein d’une même base.
+> Par exemple, un projet sur le réseau de transport d’électricité au Québec pourrait nécessiter l’utilisation de plusieurs *shapefiles* (position des centrales, position des pylônes, parcours des câbles, etc.) et aussi plusieurs données matricielles (topographie, végétation, etc.). Ainsi, il s’avère beaucoup plus efficace d’avoir l’ensemble de ces données au sein d’une même base.
 
-  De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
+> De plus, une géodatabase peut être utilisée par de multiples utilisateurs, ce qui est fort utile pour assurer le partage efficace, la mise à jour, et la cohérence des données géographiques au sein de grandes organisations, comme des entreprises ou des ministères.
 
-  Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS.
+> Malheureusement, bien que les géodatabases peuvent être lues avec `R`, elles peuvent seulement être modifiées dans ArcGIS.
 
 
 ###### GEOGRAPHIC JAVASCRIPT OBJECT NOTATION (.GEOJSON, .JSON) {-}
 
-  Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information.
+- Le format geoJSON est un format standard ouvert très utilisé en cartographie web. geoJSON est une extension du format JSON pour les données géographiques. Un fichier geoJSON contient les coordonnées des données géospatiales ainsi que d’autres informations sur les attributs. Un seul fichier est nécessaire pour stocker l’ensemble de l’information.
 
 
 ###### GOOGLE KEYHOLE MARKUP LANGUAGE (.KML, .KMZ) {-}
 
-  Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).
+- Ce format est basé sur le langage XML et est optimisé pour les navigateurs de cartographie web comme Google Maps et Google Earth. KMZ est une version compressée d’un fichier KML (KML-Zipped).
 
 
 ###### COVERAGE {-}
 
-  COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
+> COVERAGE est le format propriétaire d’ESRI, développé pour le logiciel ArcInfo, qui a précédé le format *shapefile*. C’est une autre façon de stockée les données vectorielles qui nécessite plusieurs fichiers. Bien que ce format ne soit plus utilisé lorsque de nouvelles données vectorielles sont conçues, vous pourriez être amenés à rencontrer ce format si vous devez travailler avec des données qui précédent 1990.
 
 
 ###### ARCINFO INTERCHANGE FILE (.EOO) {-}
 
-  C'est le format utilisé pour importer ou exporter des données d’ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
+> C'est le format utilisé pour importer ou exporter des données d’ArcInfo. Il fonctionne comme un fichier zip et permet de partager facilement en un seul fichier les multiples fichiers et dossiers associés au format Coverage. Il permet aussi de transférer des données matricielles de format GRID.
 
 
 ###### MAPINFO INTERCHANGE FILE (.MID, .MIF) {-}
 
-  C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
+>  C'est le format propriétaire de MapInfo, le compétiteur d’Esri. Le format *shapefile* a supplanté le format interchange qui est de moins en moins utilisé. Le fichier MIF contient la localisation géographique et la topologie, et le fichier MID contient les attributs.
 
 
 ###### WEB MAP SERVICE (WMS) {-}
 
-  N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
+> N’est pas un format de données mais plutôt un protocole de communication qui permet de visualiser des données spatiales qui sont logées sur un serveur. Les organisations gouvernementales ont souvent recours à cette méthode de partage de l’information spatiale car elle permet de s’assurer que les données diffusées sont toujours à jour. L’utilisateur peut jouer avec les paramètres de visualisation mais ne peut pas importer et modifier les données. Notez que ce protocole est utilisé à la fois pour les données vectorielles et les données matricielles.
 
 
 

--- a/Module3/index.Rmd
+++ b/Module3/index.Rmd
@@ -31,7 +31,7 @@ Vous apprendrez à utiliser les fonctions suivantes:
 - `st_transform()`
 - `ggarrange()`
 
-Dans la section Leçon, vous utiliserez des données vectorielles relatives au réseau de pistes cyclables de la ville de Montréal et aux accidents routiers impliquant des bicyclettes. 
+Dans la section Leçon, vous utiliserez des données vectorielles relatives au réseau de pistes cyclables de la ville de Montréal et aux accidents routiers impliquant des bicyclettes.
 
 Dans la section Exercice, vous utiliserez XXXXX
 
@@ -211,7 +211,7 @@ ggtitle("Limites terrestres de l'île de Montréal")
 La fonction `geom_sf()` permet de faire des représentations simples d'objets vectoriels de géométrie de type point, ligne et polygone.
 Cette fonction peut prendre plusieurs arguments^[Pour plus d'information sur la fonction `geom_sf`, consultez le chapitre [Visualise sf objects](https://ggplot2.tidyverse.org/reference/ggsf.html) [@Wickham_ggplot2_2016]]. Les arguments utilisés ici sont:
 
-- les données (`data`) 
+- les données (`data`)
 - la taille du trait avec laquelle on illustre l'objet (`size`)
 - la couleur du trait, et la couleur de la surface délimitée par le trait (`color`).
 
@@ -244,9 +244,10 @@ ggtitle("Accidents de la route avec cyclistes sur l'île de Montréal")
 
 Le symbole utilisé pour illustrer la position des accidents est défini par l'argument `pch = 19`. Il existe 25 formats de points différents prédéfinis dans `R`. Les voici:
 
-```{r plot-symbols, echo=FALSE,fig.cap="Symboles disponibles", out.width = '50%'}
+```{r plot-symbols, echo=FALSE, fig.cap="Symboles disponibles", out.width = '50%'}
 knitr::include_graphics('Module3/3_symbolesR.png')
 ```
+
 
 L'argument `cex`, quant à lui, indique le facteur par lequel la taille du symbole sera augmentée ou réduite par rapport à 1, la valeur par défaut. Par exemple, 'cex = 1.5' indique que le symbole sera 50% plus grand, alors que 0.5 indique que le symbole sera 50% plus petit.
 

--- a/_output.yml
+++ b/_output.yml
@@ -1,6 +1,7 @@
 bookdown::gitbook:
   dev: svglite
-  css: css/style.css
+  css: [css/style.css, css/toc.css, css/extra.css]
+  toc_depth: 4
   split_by: section
   config:
     toc:

--- a/css/extra.css
+++ b/css/extra.css
@@ -1,0 +1,9 @@
+p.caption {
+  font-size: .9em;
+   margin-top: 8px !important;
+   margin-bottom: 8px !important;
+}
+
+.book h5 {
+  font-size: 1.25em !important;
+}


### PR DESCRIPTION
Voila comment j'ai procédé 

1. cross-référencer une figure dans une figure: `\@ref(fig:vectomat)` => `\\@ref(fig:vectomat)`
2. captions trop gros et sous-titres de niveau 5: je gère ça dans `css/extra.css`
3.  sous-titres de niveaux 4 dans le menu de navigation => dans `_output.yml` => `toc_depth: 4`
4. Pour les listes on pourrait en discuter un peu plus, de vive voix, mais sur le chapitre 2 (données vectorielles) j'ai fait qq essais. Je te suggère de prendre les titres de niveau 6 (niveau le plus bas). Après tu peux faire des listes ou utiliser le bloc de citation, on peut toujours faire de quoi avec le css. 