### PR TITLE
 Mod3_correct_pathdatamod4

### DIFF
--- a/Module3/index.Rmd
+++ b/Module3/index.Rmd
@@ -325,7 +325,7 @@ Le format *Well-known text* (WKT) est une syntaxe standard utilisée pour repré
 
 ```{r, echo=FALSE, warning=FALSE}
 library(sf)
-S <- st_read("Module4/data/Montreal_Velo/pistes/pistes_cyclables_type.shp")
+S <- st_read("Module4/Module4_donnees/Montreal_Velo/pistes/pistes_cyclables_type.shp")
 st_crs(S)
 ```
 <br>


### PR DESCRIPTION
J'ai changé le nom du fichier de données dans le module 4 data -> Module4_donnees, mais j'avais oublié que j'utilisais aussi les données de vélo dans le module 3. Donc j'ai corrigé le path.